### PR TITLE
Fixes issue #785 - Add Jakarta Bean Validation

### DIFF
--- a/beanvalidation/bval/pom.xml
+++ b/beanvalidation/bval/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cloud.piranha.beanvalidation</groupId>
+        <artifactId>project</artifactId>
+        <version>20.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>piranha-beanvalidation-bval</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Piranha Bean Validation - Apache BVal integration</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <!-- A CDI implementation must be provided by the user -->
+        <dependency>
+            <groupId>org.apache.bval</groupId>
+            <artifactId>bval-jsr</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/beanvalidation/hibernatevalidator/pom.xml
+++ b/beanvalidation/hibernatevalidator/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cloud.piranha.beanvalidation</groupId>
+        <artifactId>project</artifactId>
+        <version>20.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>piranha-beanvalidation-hibernatevalidator</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Piranha Bean Validation - Hibernate Validator integration</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <!-- A CDI implementation must be provided by the user -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator-cdi</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/beanvalidation/pom.xml
+++ b/beanvalidation/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>cloud.piranha</groupId>
+        <artifactId>project</artifactId>
+        <version>20.6.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>cloud.piranha.beanvalidation</groupId>
+    <artifactId>project</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Piranha Bean Validation - Project</name>
+
+    <modules>
+        <module>bval</module>
+        <module>hibernatevalidator</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>cloud.piranha</groupId>
+                <artifactId>bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -235,7 +235,24 @@
                 <artifactId>openwebbeans-spi</artifactId>
                 <version>2.0.16</version>
             </dependency>
-            
+
+            <!-- Jakarta Bean Validation -->
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>2.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator-cdi</artifactId>
+                <version>6.1.5.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.bval</groupId>
+                <artifactId>bval-jsr</artifactId>
+                <version>2.0.3</version>
+            </dependency>
+
             <!-- Jakarta XML Bind -->
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>

--- a/extension/apachewebprofile/pom.xml
+++ b/extension/apachewebprofile/pom.xml
@@ -108,6 +108,12 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- Piranha Bean Validation - BVal Integration -->
+        <dependency>
+            <groupId>cloud.piranha.beanvalidation</groupId>
+            <artifactId>piranha-beanvalidation-bval</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Tyrus - WebSocket support -->
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>

--- a/extension/webprofile/pom.xml
+++ b/extension/webprofile/pom.xml
@@ -108,6 +108,13 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- Piranha Bean Validation - Hibernate Validator Integration -->
+        <dependency>
+            <groupId>cloud.piranha.beanvalidation</groupId>
+            <artifactId>piranha-beanvalidation-hibernatevalidator</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
         <!-- Tyrus - WebSocket support -->
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     
         <!-- Components -->
         <module>appserver</module>
+        <module>beanvalidation</module>
         <module>cdi</module>
         <module>faces</module>
         <module>http</module>


### PR DESCRIPTION
This is my initial attempt to add the Hibernate Validator to Piranha.

I tried to run the tests of javaee7-samples related to Bean validation, but I think the classloader isn't loading jars from WEB-INF/lib.

As I could find, the Bean Validation tests are the only ones that uses JAR while all others uses WAR, I don't know how much it can influenciate.

Fixes #785