### PR TITLE
Fixes issue #809 - Enable WebAnnotationInitializer in Piranha Server

### DIFF
--- a/extension/apachewebprofile/pom.xml
+++ b/extension/apachewebprofile/pom.xml
@@ -99,7 +99,7 @@
             <groupId>cloud.piranha.webapp</groupId>
             <artifactId>piranha-webapp-webannotation</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
         <!-- Piranha Webapplication - web.xml support -->
         <dependency>

--- a/extension/apachewebprofile/src/main/java/cloud/piranha/extension/apachewebprofile/ApacheWebProfileExtension.java
+++ b/extension/apachewebprofile/src/main/java/cloud/piranha/extension/apachewebprofile/ApacheWebProfileExtension.java
@@ -32,6 +32,7 @@ import cloud.piranha.webapp.api.WebApplicationExtensionContext;
 import cloud.piranha.webapp.annotationscan.AnnotationScanExtension;
 import cloud.piranha.webapp.scinitializer.ServletContainerInitializerExtension;
 import cloud.piranha.webapp.tempdir.TempDirExtension;
+import cloud.piranha.webapp.webservlet.WebAnnotationExtension;
 import cloud.piranha.webapp.webxml.WebXmlExtension;
 
 /**
@@ -64,6 +65,7 @@ public class ApacheWebProfileExtension implements WebApplicationExtension {
     public void extend(WebApplicationExtensionContext context) {
         context.add(AnnotationScanExtension.class);
         context.add(WebXmlExtension.class);
+        context.add(WebAnnotationExtension.class);
         context.add(TempDirExtension.class);
         context.add(ServletContainerInitializerExtension.class);
     }

--- a/extension/servlet/pom.xml
+++ b/extension/servlet/pom.xml
@@ -133,7 +133,7 @@
             <groupId>cloud.piranha.webapp</groupId>
             <artifactId>piranha-webapp-webannotation</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
         <!-- Piranha Webapplication - web.xml support -->
         <dependency>

--- a/extension/servlet/src/main/java/cloud/piranha/extension/servlet/ServletExtension.java
+++ b/extension/servlet/src/main/java/cloud/piranha/extension/servlet/ServletExtension.java
@@ -32,6 +32,7 @@ import cloud.piranha.webapp.api.WebApplicationExtensionContext;
 import cloud.piranha.webapp.annotationscan.AnnotationScanExtension;
 import cloud.piranha.webapp.scinitializer.ServletContainerInitializerExtension;
 import cloud.piranha.webapp.tempdir.TempDirExtension;
+import cloud.piranha.webapp.webservlet.WebAnnotationExtension;
 import cloud.piranha.webapp.webxml.WebXmlExtension;
 
 /**
@@ -52,6 +53,7 @@ public class ServletExtension implements WebApplicationExtension {
     public void extend(WebApplicationExtensionContext context) {
         context.add(AnnotationScanExtension.class);
         context.add(WebXmlExtension.class);
+        context.add(WebAnnotationExtension.class);
         context.add(TempDirExtension.class);
         context.add(ServletContainerInitializerExtension.class);
     }

--- a/extension/tomcat9/src/main/java/cloud/piranha/extension/tomcat9/Tomcat9Extension.java
+++ b/extension/tomcat9/src/main/java/cloud/piranha/extension/tomcat9/Tomcat9Extension.java
@@ -32,6 +32,7 @@ import cloud.piranha.webapp.api.WebApplicationExtensionContext;
 import cloud.piranha.pages.jasper.JasperExtension;
 import cloud.piranha.webapp.annotationscan.AnnotationScanExtension;
 import cloud.piranha.webapp.scinitializer.ServletContainerInitializerExtension;
+import cloud.piranha.webapp.webservlet.WebAnnotationExtension;
 import cloud.piranha.webapp.webxml.WebXmlExtension;
 
 /**
@@ -66,6 +67,7 @@ public class Tomcat9Extension implements WebApplicationExtension {
     public void extend(WebApplicationExtensionContext context) {
         context.add(AnnotationScanExtension.class);
         context.add(WebXmlExtension.class);
+        context.add(WebAnnotationExtension.class);
         context.add(JasperExtension.class);
         context.add(ServletContainerInitializerExtension.class);
     }

--- a/extension/webprofile/pom.xml
+++ b/extension/webprofile/pom.xml
@@ -99,7 +99,7 @@
             <groupId>cloud.piranha.webapp</groupId>
             <artifactId>piranha-webapp-webannotation</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
         <!-- Piranha Webapplication - web.xml support -->
         <dependency>

--- a/extension/webprofile/src/main/java/cloud/piranha/extension/webprofile/WebProfileExtension.java
+++ b/extension/webprofile/src/main/java/cloud/piranha/extension/webprofile/WebProfileExtension.java
@@ -32,6 +32,7 @@ import cloud.piranha.webapp.api.WebApplicationExtensionContext;
 import cloud.piranha.webapp.annotationscan.AnnotationScanExtension;
 import cloud.piranha.webapp.scinitializer.ServletContainerInitializerExtension;
 import cloud.piranha.webapp.tempdir.TempDirExtension;
+import cloud.piranha.webapp.webservlet.WebAnnotationExtension;
 import cloud.piranha.webapp.webxml.WebXmlExtension;
 
 /**
@@ -64,6 +65,7 @@ public class WebProfileExtension implements WebApplicationExtension {
     public void extend(WebApplicationExtensionContext context) {
         context.add(AnnotationScanExtension.class);
         context.add(WebXmlExtension.class);
+        context.add(WebAnnotationExtension.class);
         context.add(TempDirExtension.class);
         context.add(ServletContainerInitializerExtension.class);
     }

--- a/webapp/webannotation/src/main/java/cloud/piranha/webapp/webservlet/WebAnnotationExtension.java
+++ b/webapp/webannotation/src/main/java/cloud/piranha/webapp/webservlet/WebAnnotationExtension.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2020 Manorrock.com. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package cloud.piranha.webapp.webservlet;
+
+import cloud.piranha.webapp.api.WebApplication;
+import cloud.piranha.webapp.api.WebApplicationExtension;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.ServletContainerInitializer;
+
+/**
+ * The extension for WebAnnotation processing.
+ *
+ * @author Thiago Henrique Hupner
+ */
+public class WebAnnotationExtension implements WebApplicationExtension {
+
+    /**
+     * Stores the logger.
+     */
+    private static final Logger LOGGER = Logger.getLogger(WebAnnotationExtension.class.getName());
+
+    /**
+     * Configure the web application.
+     *
+     * @param webApplication the web application.
+     */
+    @Override
+    public void configure(WebApplication webApplication) {
+        try {
+            ClassLoader classLoader = webApplication.getClassLoader();
+            Class<? extends ServletContainerInitializer> clazz
+                    = classLoader
+                        .loadClass(WebAnnotationInitializer.class.getName())
+                        .asSubclass(ServletContainerInitializer.class);
+            ServletContainerInitializer initializer = clazz.getDeclaredConstructor().newInstance();
+            webApplication.addInitializer(initializer);
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException
+                | InstantiationException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException ex) {
+            LOGGER.log(Level.WARNING, "Unable to enable the WebAnnotationExtension", ex);
+        }
+    }
+}


### PR DESCRIPTION
Currently, the annotation class is included but is not enabled because it doesn't contain the service file, so the ServiceLoader in Piranha Server doesn't find it.

Fixes #809 