### PR TITLE
Fixes issue #831 - Add --ssl for SSL support

### DIFF
--- a/extension/micro-core/src/main/java/cloud/piranha/micro/MicroInnerDeployer.java
+++ b/extension/micro-core/src/main/java/cloud/piranha/micro/MicroInnerDeployer.java
@@ -130,9 +130,9 @@ public class MicroInnerDeployer {
             WebApplication webApplication = getWebApplication(applicationArchive, classLoader);
             
             LOGGER.info(
-                "Starting web application " + applicationArchive.getName() + " on Piranha Micro" + webApplication.getAttribute(MICRO_PIRANHA));
-                      
-            
+                "Starting web application " + applicationArchive.getName() + " on Piranha Micro " + webApplication.getAttribute(MICRO_PIRANHA));
+
+
             // The global archive stream handler is set to resolve "shrinkwrap://" URLs (created from strings).
             // Such URLs come into being primarily when code takes resolves a class or resource from the class loader by URL
             // and then takes the string form of the URL representing the class or resource.
@@ -187,7 +187,7 @@ public class MicroInnerDeployer {
             ServiceLoader<HttpServer> httpServers = ServiceLoader.load(HttpServer.class);
             httpServer = httpServers.findFirst().orElseThrow();
             httpServer.setServerPort(port);
-            httpServer.setSSL(false);
+            httpServer.setSSL(Boolean.getBoolean("piranha.http.ssl"));
             httpServer.setHttpServerProcessor(webApplicationServer);
             httpServer.start();
             

--- a/http/grizzly/src/main/java/cloud/piranha/http/grizzly/GrizzlyHttpServer.java
+++ b/http/grizzly/src/main/java/cloud/piranha/http/grizzly/GrizzlyHttpServer.java
@@ -140,6 +140,7 @@ public class GrizzlyHttpServer implements cloud.piranha.http.api.HttpServer {
     public void start() {
         if (httpServer == null) {
             httpServer = HttpServer.createSimpleServer(null, port);
+            httpServer.getListener("grizzly").setSecure(ssl);
         }
         addHttpHandler();
         try {

--- a/http/netty/src/main/java/cloud/piranha/http/netty/NettyHttpServer.java
+++ b/http/netty/src/main/java/cloud/piranha/http/netty/NettyHttpServer.java
@@ -68,7 +68,7 @@ public class NettyHttpServer implements HttpServer {
      */
     private EventLoopGroup workerGroup;
 
-    /***
+    /**
      * Stores the SSL flag
      */
     private boolean ssl;
@@ -121,7 +121,7 @@ public class NettyHttpServer implements HttpServer {
         ServerBootstrap bootstrap = new ServerBootstrap();
         bootstrap.group(bossGroup, workerGroup)
                 .channel(NioServerSocketChannel.class)
-                .childHandler(new NettyHttpServerInitializer(httpServerProcessor))
+                .childHandler(new NettyHttpServerInitializer(httpServerProcessor, ssl))
                 .bind(serverPort).awaitUninterruptibly();
     }
 

--- a/http/undertow/src/main/java/cloud/piranha/http/undertow/UndertowHttpRequest.java
+++ b/http/undertow/src/main/java/cloud/piranha/http/undertow/UndertowHttpRequest.java
@@ -88,6 +88,9 @@ public class UndertowHttpRequest implements HttpServerRequest {
      */
     @Override
     public InputStream getInputStream() {
+        if (!exchange.isBlocking()) {
+            exchange.startBlocking();
+        }
         return exchange.getInputStream();
     }
 

--- a/micro/src/main/java/cloud/piranha/micro/MicroPiranha.java
+++ b/micro/src/main/java/cloud/piranha/micro/MicroPiranha.java
@@ -106,6 +106,10 @@ public class MicroPiranha implements Runnable {
                 if (arguments[i].equals("--http")) {
                     httpServer = arguments[i + 1];
                 }
+
+                if (arguments[i].equals("--ssl")) {
+                    System.setProperty("piranha.http.ssl", "true");
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #831 

We need to supply two properties to get the SSL to work besides the '--ssl' flag: 
_javax.net.ssl.keyStore_ and _javax.net.ssl.keyStorePassword_ (like Piranha Server).

Only the default port will have the SSL. I think we need to open other issue to enable two HTTP ports, one for HTTPS (like 8443) and one for HTTP (8080).