### PR TITLE
Fixes issue #1059 - Change the module names to follow the (main) package name

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -25,7 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.api {
+module cloud.piranha.api {
     exports cloud.piranha.api;
 
     // TODO Remove this requires.
@@ -33,5 +33,5 @@ module piranha.api {
     //  in the pom.xml as provided.
     //  However looks like we don't need it
     //  as provided too
-    requires static piranha.http.api;
+    requires static cloud.piranha.http.api;
 }

--- a/appserver/api/src/main/java/module-info.java
+++ b/appserver/api/src/main/java/module-info.java
@@ -25,9 +25,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.appserver.api {
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
+module cloud.piranha.appserver.api {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
 
     exports cloud.piranha.appserver.api;
 }

--- a/appserver/impl/src/main/java/module-info.java
+++ b/appserver/impl/src/main/java/module-info.java
@@ -26,18 +26,18 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.appserver.impl {
-    requires java.logging;
+module cloud.piranha.appserver.impl {
+    requires cloud.piranha.appserver.api;
+    requires cloud.piranha.http.api;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
 
-    requires piranha.appserver.api;
-    requires piranha.http.api;
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
+    requires java.logging;
 
     exports cloud.piranha.appserver.impl;
 
     // Tests
+    requires static cloud.piranha.http.impl;
     requires static java.net.http;
-    requires static piranha.http.impl;
 }

--- a/arquillian/server/src/main/java/module-info.java
+++ b/arquillian/server/src/main/java/module-info.java
@@ -26,13 +26,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.arquillian.server {
+module cloud.piranha.arquillian.server {
+    requires cloud.piranha.micro;
+
     requires arquillian.container.spi;
     requires arquillian.core.spi;
 
     requires java.logging;
 
-    requires piranha.micro;
-    requires shrinkwrap.descriptors.api.base;
     requires shrinkwrap.api;
+    requires shrinkwrap.descriptors.api.base;
 }

--- a/cdi/openwebbeans/src/main/java/module-info.java
+++ b/cdi/openwebbeans/src/main/java/module-info.java
@@ -26,9 +26,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.cdi.openwebbeans {
-    requires jakarta.enterprise.cdi.api;
+module cloud.piranha.cdi.openwebbeans {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
 
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
+    requires jakarta.enterprise.cdi.api;
 }

--- a/cdi/weld/src/main/java/module-info.java
+++ b/cdi/weld/src/main/java/module-info.java
@@ -26,16 +26,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.cdi.weld {
-    requires jakarta.security.enterprise.api;
+module cloud.piranha.cdi.weld {
+    requires cloud.piranha.naming.impl;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
+
     requires jakarta.enterprise.cdi.api;
+    requires jakarta.security.enterprise.api;
 
     requires java.naming;
-
-    requires piranha.naming.impl;
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
 
     requires weld.core.impl;
     requires weld.spi;

--- a/cli/src/main/java/module-info.java
+++ b/cli/src/main/java/module-info.java
@@ -26,6 +26,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.cli {
+module cloud.piranha.cli {
 
 }

--- a/cli/src/main/java/module-info.java
+++ b/cli/src/main/java/module-info.java
@@ -27,5 +27,4 @@
  */
 
 module cloud.piranha.cli {
-
 }

--- a/database/environment/src/main/java/module-info.java
+++ b/database/environment/src/main/java/module-info.java
@@ -30,7 +30,7 @@ import cloud.piranha.database.environment.EnvironmentDriver;
 
 import java.sql.Driver;
 
-module piranha.database.environment {
+module cloud.piranha.database.environment {
     requires java.sql;
 
     exports cloud.piranha.database.environment;

--- a/database/property/src/main/java/module-info.java
+++ b/database/property/src/main/java/module-info.java
@@ -30,7 +30,7 @@ import cloud.piranha.database.property.PropertyDriver;
 
 import java.sql.Driver;
 
-module piranha.database.property {
+module cloud.piranha.database.property {
     requires java.sql;
 
     provides Driver with PropertyDriver;

--- a/embedded/src/main/java/module-info.java
+++ b/embedded/src/main/java/module-info.java
@@ -26,13 +26,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.embedded {
-    requires piranha.api;
-    requires piranha.resource.api;
-    requires piranha.resource;
-    requires piranha.servlet.api;
-    requires piranha.webapp.impl;
-    requires piranha.webapp.api;
+module cloud.piranha.embedded {
+    requires cloud.piranha.api;
+    requires cloud.piranha.resource.api;
+    requires cloud.piranha.resource;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.impl;
+    requires cloud.piranha.webapp.api;
 
     exports cloud.piranha.embedded;
 }

--- a/extension/jakartaee/src/main/java/module-info.java
+++ b/extension/jakartaee/src/main/java/module-info.java
@@ -31,6 +31,6 @@ module cloud.piranha.extension.jakartaee {
     requires cloud.piranha.webapp.api;
     requires cloud.piranha.webapp.scinitializer;
     requires cloud.piranha.webapp.tempdir;
-    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webannotation;
     requires cloud.piranha.webapp.webxml;
 }

--- a/extension/jakartaee/src/main/java/module-info.java
+++ b/extension/jakartaee/src/main/java/module-info.java
@@ -25,12 +25,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.extension.jakartaee {
-    requires piranha.pages.jasper;
-    requires piranha.webapp.annotationscan;
-    requires piranha.webapp.api;
-    requires piranha.webapp.scinitializer;
-    requires piranha.webapp.tempdir;
-    requires piranha.webapp.webannotation;
-    requires piranha.webapp.webxml;
+module cloud.piranha.extension.jakartaee {
+    requires cloud.piranha.pages.jasper;
+    requires cloud.piranha.webapp.annotationscan;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.scinitializer;
+    requires cloud.piranha.webapp.tempdir;
+    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webxml;
 }

--- a/extension/micro-core/src/main/java/module-info.java
+++ b/extension/micro-core/src/main/java/module-info.java
@@ -33,7 +33,18 @@ import org.jboss.weld.environment.deployment.discovery.BeanArchiveHandler;
 
 import javax.enterprise.inject.spi.Extension;
 
-module piranha.extension.micro.core {
+module cloud.piranha.micro.core {
+    requires cloud.piranha.api;
+    requires cloud.piranha.appserver.impl;
+    requires cloud.piranha.cdi.weld;
+    requires cloud.piranha.http.api;
+    requires cloud.piranha.naming.impl;
+    requires cloud.piranha.resource.shrinkwrap;
+    requires cloud.piranha.security.jakarta;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
+
     requires jakarta.enterprise.cdi.api;
     requires jakarta.security.enterprise.api;
 
@@ -43,17 +54,6 @@ module piranha.extension.micro.core {
     requires java.xml;
 
     requires org.jboss.jandex;
-
-    requires piranha.api;
-    requires piranha.appserver.impl;
-    requires piranha.cdi.weld;
-    requires piranha.http.api;
-    requires piranha.naming.impl;
-    requires piranha.resource.shrinkwrap;
-    requires piranha.security.jakarta;
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
 
     requires shrinkwrap.api;
 

--- a/extension/micro/src/main/java/module-info.java
+++ b/extension/micro/src/main/java/module-info.java
@@ -28,12 +28,12 @@
 import cloud.piranha.extension.micro.MicroExtension;
 import cloud.piranha.webapp.api.WebApplicationExtension;
 
-module piranha.extension.micro {
-    requires piranha.security.jakarta;
-    requires piranha.webapp.api;
-    requires piranha.webapp.scinitializer;
-    requires piranha.webapp.webxml;
-    requires piranha.webapp.webannotation;
+module cloud.piranha.extension.micro {
+    requires cloud.piranha.security.jakarta;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.scinitializer;
+    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webxml;
 
     provides WebApplicationExtension with MicroExtension;
 }

--- a/extension/micro/src/main/java/module-info.java
+++ b/extension/micro/src/main/java/module-info.java
@@ -32,7 +32,7 @@ module cloud.piranha.extension.micro {
     requires cloud.piranha.security.jakarta;
     requires cloud.piranha.webapp.api;
     requires cloud.piranha.webapp.scinitializer;
-    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webannotation;
     requires cloud.piranha.webapp.webxml;
 
     provides WebApplicationExtension with MicroExtension;

--- a/extension/microprofile/src/main/java/module-info.java
+++ b/extension/microprofile/src/main/java/module-info.java
@@ -30,7 +30,7 @@ import cloud.piranha.extension.microprofile.MicroProfileExtension;
 import cloud.piranha.webapp.api.WebApplicationExtension;
 
 module cloud.piranha.extension.microprofile {
-    requires cloud.piranha.omnifaces.jwt;
+    requires cloud.piranha.microprofile.omnifaces.jwt;
     requires cloud.piranha.security.jakarta;
     requires cloud.piranha.webapp.api;
     requires cloud.piranha.webapp.scinitializer;

--- a/extension/microprofile/src/main/java/module-info.java
+++ b/extension/microprofile/src/main/java/module-info.java
@@ -29,12 +29,12 @@
 import cloud.piranha.extension.microprofile.MicroProfileExtension;
 import cloud.piranha.webapp.api.WebApplicationExtension;
 
-module piranha.extension.microprofile {
-    requires piranha.microprofile.omnifaces.jwt;
-    requires piranha.security.jakarta;
-    requires piranha.webapp.api;
-    requires piranha.webapp.scinitializer;
-    requires piranha.webapp.webxml;
+module cloud.piranha.extension.microprofile {
+    requires cloud.piranha.omnifaces.jwt;
+    requires cloud.piranha.security.jakarta;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.scinitializer;
+    requires cloud.piranha.webapp.webxml;
 
     provides WebApplicationExtension with MicroProfileExtension;
 }

--- a/extension/servlet/src/main/java/module-info.java
+++ b/extension/servlet/src/main/java/module-info.java
@@ -26,14 +26,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.extension.servlet {
-    requires piranha.pages.jasper;
-    requires piranha.webapp.annotationscan;
-    requires piranha.webapp.api;
-    requires piranha.webapp.scinitializer;
-    requires piranha.webapp.tempdir;
-    requires piranha.webapp.webannotation;
-    requires piranha.webapp.webxml;
+module cloud.piranha.extension.servlet {
+    requires cloud.piranha.pages.jasper;
+    requires cloud.piranha.webapp.annotationscan;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.scinitializer;
+    requires cloud.piranha.webapp.tempdir;
+    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webxml;
 
     exports cloud.piranha.extension.servlet;
 }

--- a/extension/servlet/src/main/java/module-info.java
+++ b/extension/servlet/src/main/java/module-info.java
@@ -32,7 +32,7 @@ module cloud.piranha.extension.servlet {
     requires cloud.piranha.webapp.api;
     requires cloud.piranha.webapp.scinitializer;
     requires cloud.piranha.webapp.tempdir;
-    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webannotation;
     requires cloud.piranha.webapp.webxml;
 
     exports cloud.piranha.extension.servlet;

--- a/extension/tomcat9/src/main/java/module-info.java
+++ b/extension/tomcat9/src/main/java/module-info.java
@@ -27,12 +27,12 @@
  */
 
 // It is not recommend to use digits in the module name
-module piranha.extension.tomcat9 {
-    requires piranha.pages.jasper;
-    requires piranha.webapp.annotationscan;
-    requires piranha.webapp.api;
-    requires piranha.webapp.scinitializer;
-    requires piranha.webapp.tempdir;
-    requires piranha.webapp.webxml;
-    requires piranha.webapp.webannotation;
+module cloud.piranha.extension.tomcat9 {
+    requires cloud.piranha.pages.jasper;
+    requires cloud.piranha.webapp.annotationscan;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.scinitializer;
+    requires cloud.piranha.webapp.tempdir;
+    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webxml;
 }

--- a/extension/tomcat9/src/main/java/module-info.java
+++ b/extension/tomcat9/src/main/java/module-info.java
@@ -33,6 +33,6 @@ module cloud.piranha.extension.tomcat9 {
     requires cloud.piranha.webapp.api;
     requires cloud.piranha.webapp.scinitializer;
     requires cloud.piranha.webapp.tempdir;
-    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webannotation;
     requires cloud.piranha.webapp.webxml;
 }

--- a/extension/webprofile/src/main/java/module-info.java
+++ b/extension/webprofile/src/main/java/module-info.java
@@ -26,11 +26,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.extension.webprofile {
-    requires piranha.webapp.annotationscan;
-    requires piranha.webapp.api;
-    requires piranha.webapp.scinitializer;
-    requires piranha.webapp.tempdir;
-    requires piranha.webapp.webxml;
-    requires piranha.webapp.webannotation;
+module cloud.piranha.extension.webprofile {
+    requires cloud.piranha.webapp.annotationscan;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.scinitializer;
+    requires cloud.piranha.webapp.tempdir;
+    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webxml;
 }

--- a/extension/webprofile/src/main/java/module-info.java
+++ b/extension/webprofile/src/main/java/module-info.java
@@ -31,6 +31,6 @@ module cloud.piranha.extension.webprofile {
     requires cloud.piranha.webapp.api;
     requires cloud.piranha.webapp.scinitializer;
     requires cloud.piranha.webapp.tempdir;
-    requires cloud.piranha.webapp.webservlet;
+    requires cloud.piranha.webapp.webannotation;
     requires cloud.piranha.webapp.webxml;
 }

--- a/faces/mojarra/src/main/java/module-info.java
+++ b/faces/mojarra/src/main/java/module-info.java
@@ -26,8 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.faces.mojarra {
-    requires piranha.servlet.api;
+module cloud.piranha.faces.mojarra {
+    requires cloud.piranha.servlet.api;
 
-    requires static piranha.pages.jasper;
+    requires static cloud.piranha.pages.jasper;
 }

--- a/faces/myfaces/src/main/java/module-info.java
+++ b/faces/myfaces/src/main/java/module-info.java
@@ -26,8 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.faces.myfaces {
-    requires piranha.servlet.api;
+module cloud.piranha.faces.myfaces {
+    requires cloud.piranha.servlet.api;
 
-    requires static piranha.pages.jasper;
+    requires static cloud.piranha.pages.jasper;
 }

--- a/http/api/src/main/java/module-info.java
+++ b/http/api/src/main/java/module-info.java
@@ -26,6 +26,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.http.api {
+module cloud.piranha.http.api {
     exports cloud.piranha.http.api;
 }

--- a/http/grizzly/src/main/java/module-info.java
+++ b/http/grizzly/src/main/java/module-info.java
@@ -29,16 +29,16 @@
 import cloud.piranha.http.api.HttpServer;
 import cloud.piranha.http.grizzly.GrizzlyHttpServer;
 
-module piranha.http.grizzly {
+module cloud.piranha.http.grizzly {
+    requires cloud.piranha.http.api;
+    requires cloud.piranha.http.impl;
+    requires cloud.piranha.webapp.impl;
+
     requires java.logging;
 
     requires grizzly.framework;
     requires grizzly.http;
     requires grizzly.http.server;
-
-    requires piranha.http.api;
-    requires piranha.http.impl;
-    requires piranha.webapp.impl;
 
     provides HttpServer with GrizzlyHttpServer;
 }

--- a/http/impl/src/main/java/module-info.java
+++ b/http/impl/src/main/java/module-info.java
@@ -29,8 +29,9 @@
 import cloud.piranha.http.api.HttpServer;
 import cloud.piranha.http.impl.DefaultHttpServer;
 
-module piranha.http.impl {
-    requires piranha.http.api;
+module cloud.piranha.http.impl {
+    requires cloud.piranha.http.api;
+
     requires java.logging;
 
     exports cloud.piranha.http.impl;

--- a/http/netty/src/main/java/module-info.java
+++ b/http/netty/src/main/java/module-info.java
@@ -29,14 +29,14 @@
 import cloud.piranha.http.api.HttpServer;
 import cloud.piranha.http.netty.NettyHttpServer;
 
-module piranha.http.netty {
+module cloud.piranha.http.netty {
+    requires cloud.piranha.http.api;
+    requires cloud.piranha.http.impl;
+    requires cloud.piranha.webapp.impl;
+
     requires io.netty.all;
 
     requires java.logging;
-
-    requires piranha.http.api;
-    requires piranha.http.impl;
-    requires piranha.webapp.impl;
 
     provides HttpServer with NettyHttpServer;
 }

--- a/http/singlethread/src/main/java/module-info.java
+++ b/http/singlethread/src/main/java/module-info.java
@@ -29,12 +29,12 @@
 import cloud.piranha.http.api.HttpServer;
 import cloud.piranha.http.singlethread.SingleThreadHttpServer;
 
-module piranha.http.singlethread {
-    requires java.logging;
+module cloud.piranha.http.singlethread {
+    requires cloud.piranha.http.api;
+    requires cloud.piranha.http.impl;
+    requires cloud.piranha.webapp.impl;
 
-    requires piranha.http.api;
-    requires piranha.http.impl;
-    requires piranha.webapp.impl;
+    requires java.logging;
 
     provides HttpServer with SingleThreadHttpServer;
 }

--- a/http/test-api/src/main/java/module-info.java
+++ b/http/test-api/src/main/java/module-info.java
@@ -26,9 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.http.test.api {
+module cloud.piranha.http.test.api {
+    requires cloud.piranha.http.api;
+
     requires java.net.http;
-    requires piranha.http.api;
+
     requires org.junit.jupiter.api;
+
     exports cloud.piranha.http.test.api;
 }

--- a/http/undertow/src/main/java/module-info.java
+++ b/http/undertow/src/main/java/module-info.java
@@ -29,12 +29,12 @@
 import cloud.piranha.http.api.HttpServer;
 import cloud.piranha.http.undertow.UndertowHttpServer;
 
-module piranha.http.undertow {
-    requires java.logging;
+module cloud.piranha.http.undertow {
+    requires cloud.piranha.http.api;
+    requires cloud.piranha.http.impl;
+    requires cloud.piranha.webapp.impl;
 
-    requires piranha.http.api;
-    requires piranha.http.impl;
-    requires piranha.webapp.impl;
+    requires java.logging;
 
     requires undertow.core;
 

--- a/maven/plugins/micro/src/main/java/module-info.java
+++ b/maven/plugins/micro/src/main/java/module-info.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.micro.maven.plugin {
+module cloud.piranha.maven.plugins.micro {
     requires maven.plugin.annotations;
     requires maven.plugin.api;
 }

--- a/micro/src/main/java/module-info.java
+++ b/micro/src/main/java/module-info.java
@@ -25,14 +25,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.micro {
+module cloud.piranha.micro {
+    requires cloud.piranha.api;
+    requires cloud.piranha.resource;
+    requires cloud.piranha.resource.shrinkwrap;
+
     requires java.logging;
 
     requires org.jboss.jandex;
-
-    requires piranha.api;
-    requires piranha.resource;
-    requires piranha.resource.shrinkwrap;
 
     requires shrinkwrap.api;
     requires shrinkwrap.resolver.api.maven;

--- a/microprofile/omnifaces/jwt/src/main/java/module-info.java
+++ b/microprofile/omnifaces/jwt/src/main/java/module-info.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module cloud.piranha.omnifaces.jwt {
+module cloud.piranha.microprofile.omnifaces.jwt {
     requires cloud.piranha.webapp.api;
 
     requires java.annotation;

--- a/microprofile/omnifaces/jwt/src/main/java/module-info.java
+++ b/microprofile/omnifaces/jwt/src/main/java/module-info.java
@@ -26,15 +26,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.microprofile.omnifaces.jwt {
+module cloud.piranha.omnifaces.jwt {
+    requires cloud.piranha.webapp.api;
+
     requires java.annotation;
     requires java.ws.rs;
 
     requires jersey.common;
 
     requires microprofile.jwt.auth;
-
-    requires piranha.webapp.api;
 
     exports cloud.piranha.omnifaces.jwt;
 }

--- a/microprofile/smallrye/health/src/main/java/module-info.java
+++ b/microprofile/smallrye/health/src/main/java/module-info.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module cloud.piranha.smallrye.health {
+module cloud.piranha.microprofile.smallrye.health {
     requires cloud.piranha.servlet.api;
     requires static cloud.piranha.webapp.api;
 

--- a/microprofile/smallrye/health/src/main/java/module-info.java
+++ b/microprofile/smallrye/health/src/main/java/module-info.java
@@ -26,11 +26,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.microprofile.smallrye.health {
-    requires jakarta.inject.api;
+module cloud.piranha.smallrye.health {
+    requires cloud.piranha.servlet.api;
+    requires static cloud.piranha.webapp.api;
 
-    requires piranha.servlet.api;
-    requires static piranha.webapp.api;
+    requires jakarta.inject.api;
 
     requires smallrye.health;
 }

--- a/monitor/jmx/src/main/java/module-info.java
+++ b/monitor/jmx/src/main/java/module-info.java
@@ -30,12 +30,12 @@ import cloud.piranha.monitor.jmx.JMXServerInitializer;
 
 import javax.servlet.ServletContainerInitializer;
 
-module piranha.monitor.jmx {
+module cloud.piranha.monitor.jmx {
+    requires cloud.piranha.api;
+    requires cloud.piranha.servlet.api;
+
     requires java.logging;
     requires java.management;
-
-    requires piranha.api;
-    requires piranha.servlet.api;
 
     provides ServletContainerInitializer with JMXServerInitializer;
 }

--- a/naming/impl/src/main/java/module-info.java
+++ b/naming/impl/src/main/java/module-info.java
@@ -26,7 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.naming.impl {
+module cloud.piranha.naming.impl {
     requires java.naming;
+
     exports cloud.piranha.naming.impl;
 }

--- a/nano/src/main/java/module-info.java
+++ b/nano/src/main/java/module-info.java
@@ -26,13 +26,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.nano {
-    requires piranha.api;
-    requires piranha.resource.api;
-    requires piranha.resource;
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
+module cloud.piranha.nano {
+    requires cloud.piranha.api;
+    requires cloud.piranha.resource.api;
+    requires cloud.piranha.resource;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
 
     exports cloud.piranha.nano;
 }

--- a/pages/jasper/src/main/java/module-info.java
+++ b/pages/jasper/src/main/java/module-info.java
@@ -26,14 +26,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.pages.jasper {
+module cloud.piranha.pages.jasper {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+
     requires jakarta.servlet.jsp.api;
     requires jakarta.servlet.jsp;
 
     requires java.logging;
-
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
 
     exports cloud.piranha.pages.jasper;
 }

--- a/resource/api/src/main/java/module-info.java
+++ b/resource/api/src/main/java/module-info.java
@@ -25,6 +25,6 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.resource.api {
+module cloud.piranha.resource.api {
     exports cloud.piranha.resource.api;
 }

--- a/resource/impl/src/main/java/module-info.java
+++ b/resource/impl/src/main/java/module-info.java
@@ -25,8 +25,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.resource {
-    requires piranha.resource.api;
+module cloud.piranha.resource {
+    requires cloud.piranha.resource.api;
 
     exports cloud.piranha.resource;
 }

--- a/resource/shrinkwrap/src/main/java/module-info.java
+++ b/resource/shrinkwrap/src/main/java/module-info.java
@@ -26,14 +26,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.resource.shrinkwrap {
-    requires piranha.resource.api;
-    requires piranha.resource;
-    requires static piranha.webapp.api;
+module cloud.piranha.resource.shrinkwrap {
+    requires cloud.piranha.resource.api;
+    requires cloud.piranha.resource;
+    requires static cloud.piranha.webapp.api;
 
     requires shrinkwrap.api;
 
     exports cloud.piranha.resource.shrinkwrap;
 
-    requires static piranha.webapp.impl;
+    requires static cloud.piranha.webapp.impl;
 }

--- a/security/eleos/src/main/java/module-info.java
+++ b/security/eleos/src/main/java/module-info.java
@@ -26,15 +26,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.security.eleos {
+module cloud.piranha.security.eleos {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+
     requires eleos;
 
     requires java.security.auth.message;
 
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-
     exports cloud.piranha.security.eleos;
 
-    requires static piranha.webapp.impl;
+    requires static cloud.piranha.webapp.impl;
 }

--- a/security/exousia/src/main/java/module-info.java
+++ b/security/exousia/src/main/java/module-info.java
@@ -26,14 +26,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.security.exousia {
+module cloud.piranha.security.exousia {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
+
     requires exousia;
 
     requires java.security.jacc;
-
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
 
     exports cloud.piranha.security.exousia;
 }

--- a/security/jakarta/src/main/java/module-info.java
+++ b/security/jakarta/src/main/java/module-info.java
@@ -26,21 +26,21 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.security.jakarta {
+module cloud.piranha.security.jakarta {
+    requires cloud.piranha.cdi.weld;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.security.eleos;
+    requires cloud.piranha.security.exousia;
+    requires cloud.piranha.security.soteria;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
+
     requires eleos;
 
     requires exousia;
 
     requires java.logging;
     requires java.naming;
-
-    requires piranha.cdi.weld;
-    requires piranha.servlet.api;
-    requires piranha.security.eleos;
-    requires piranha.security.exousia;
-    requires piranha.security.soteria;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
 
     exports cloud.piranha.security.jakarta;
 }

--- a/security/soteria/src/main/java/module-info.java
+++ b/security/soteria/src/main/java/module-info.java
@@ -26,7 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.security.soteria {
+module cloud.piranha.security.soteria {
+    requires cloud.piranha.naming.impl;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
+
     requires jakarta.enterprise.cdi.api;
     requires jakarta.security.enterprise.api;
 
@@ -34,11 +39,6 @@ module piranha.security.soteria {
     requires java.naming;
 
     requires javax.security.enterprise;
-
-    requires piranha.naming.impl;
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
 
     exports cloud.piranha.security.soteria;
 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -28,17 +28,17 @@
 
 import cloud.piranha.webapp.api.WebApplicationExtension;
 
-module piranha.server {
-    requires java.logging;
+module cloud.piranha.server {
+    requires cloud.piranha.api;
+    requires cloud.piranha.appserver.impl;
+    requires cloud.piranha.extension.servlet;
+    requires cloud.piranha.http.impl;
+    requires cloud.piranha.naming.impl;
+    requires cloud.piranha.resource;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
 
-    requires piranha.api;
-    requires piranha.appserver.impl;
-    requires piranha.extension.servlet;
-    requires piranha.http.impl;
-    requires piranha.naming.impl;
-    requires piranha.resource;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
+    requires java.logging;
 
     uses WebApplicationExtension;
 }

--- a/servlet/api/src/main/java/module-info.java
+++ b/servlet/api/src/main/java/module-info.java
@@ -25,7 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.servlet.api {
+module cloud.piranha.servlet.api {
     exports javax.servlet;
     exports javax.servlet.annotation;
     exports javax.servlet.descriptor;

--- a/session/hazelcast/src/main/java/module-info.java
+++ b/session/hazelcast/src/main/java/module-info.java
@@ -30,12 +30,12 @@ import cloud.piranha.session.hazelcast.HazelcastInitializer;
 
 import javax.servlet.ServletContainerInitializer;
 
-module piranha.session.hazelcast {
-    requires com.hazelcast.core;
+module cloud.piranha.session.hazelcast {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
 
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
+    requires com.hazelcast.core;
 
     provides ServletContainerInitializer with HazelcastInitializer;
 }

--- a/transaction/api/src/main/java/module-info.java
+++ b/transaction/api/src/main/java/module-info.java
@@ -25,9 +25,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.transaction.api {
-    requires jakarta.interceptor.api;
+module cloud.piranha.transaction.api {
     requires jakarta.enterprise.cdi.api;
+    requires jakarta.interceptor.api;
 
     requires java.rmi;
     requires java.transaction.xa;

--- a/transaction/nonxa/src/main/java/module-info.java
+++ b/transaction/nonxa/src/main/java/module-info.java
@@ -25,15 +25,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.transaction.nonxa {
-    requires java.transaction.xa;
+module cloud.piranha.transaction.nonxa {
+    requires cloud.piranha.transaction.api;
 
-    requires piranha.transaction.api;
+    requires java.transaction.xa;
 
     exports cloud.piranha.transaction.nonxa;
 
     // Tests
     requires static java.naming;
     requires static java.sql;
+
     opens cloud.piranha.transaction.nonxa;
 }

--- a/upload/apache/src/main/java/module-info.java
+++ b/upload/apache/src/main/java/module-info.java
@@ -29,14 +29,14 @@ import cloud.piranha.upload.apache.ApacheMultiPartInitializer;
 
 import javax.servlet.ServletContainerInitializer;
 
-module piranha.upload.apache {
+module cloud.piranha.upload.apache {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
+
     requires commons.fileupload;
 
     requires java.logging;
-
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
 
     provides ServletContainerInitializer with ApacheMultiPartInitializer;
 }

--- a/webapp/annotationscan/src/main/java/module-info.java
+++ b/webapp/annotationscan/src/main/java/module-info.java
@@ -1,7 +1,3 @@
-import cloud.piranha.webapp.api.WebApplicationExtension;
-
-import javax.servlet.ServletContainerInitializer;
-
 /*
  * Copyright (c) 2002-2020 Manorrock.com. All Rights Reserved.
  *
@@ -29,13 +25,13 @@ import javax.servlet.ServletContainerInitializer;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.webapp.annotationscan {
-    requires java.logging;
+module cloud.piranha.webapp.annotationscan {
+    requires cloud.piranha.resource.api;
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
 
-    requires piranha.resource.api;
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
+    requires java.logging;
 
     exports cloud.piranha.webapp.annotationscan;
 }

--- a/webapp/api/src/main/java/module-info.java
+++ b/webapp/api/src/main/java/module-info.java
@@ -25,10 +25,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.webapp.api {
-    requires static piranha.http.api;
-    requires static piranha.resource.api;
-    requires static piranha.servlet.api;
+module cloud.piranha.webapp.api {
+    requires static cloud.piranha.http.api;
+    requires static cloud.piranha.resource.api;
+    requires static cloud.piranha.servlet.api;
 
     exports cloud.piranha.webapp.api;
 }

--- a/webapp/impl/src/main/java/module-info.java
+++ b/webapp/impl/src/main/java/module-info.java
@@ -25,16 +25,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-module piranha.webapp.impl {
-    requires java.logging;
+module cloud.piranha.webapp.impl {
+    requires cloud.piranha.appserver.api;
+    requires cloud.piranha.http.api;
+    requires cloud.piranha.http.impl;
+    requires cloud.piranha.resource.api;
+    requires cloud.piranha.resource;
+    requires transitive cloud.piranha.servlet.api;
+    requires transitive cloud.piranha.webapp.api;
 
-    requires piranha.appserver.api;
-    requires piranha.http.api;
-    requires piranha.http.impl;
-    requires piranha.resource.api;
-    requires piranha.resource;
-    requires transitive piranha.servlet.api;
-    requires transitive piranha.webapp.api;
+    requires java.logging;
 
     exports cloud.piranha.webapp.impl;
 

--- a/webapp/scinitializer/src/main/java/module-info.java
+++ b/webapp/scinitializer/src/main/java/module-info.java
@@ -28,11 +28,11 @@
 
 import javax.servlet.ServletContainerInitializer;
 
-module piranha.webapp.scinitializer {
-    requires java.logging;
+module cloud.piranha.webapp.scinitializer {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
 
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
+    requires java.logging;
 
     uses ServletContainerInitializer;
 

--- a/webapp/tempdir/src/main/java/module-info.java
+++ b/webapp/tempdir/src/main/java/module-info.java
@@ -26,11 +26,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.webapp.tempdir {
-    requires java.logging;
+module cloud.piranha.webapp.tempdir {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
 
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
+    requires java.logging;
 
     exports cloud.piranha.webapp.tempdir;
 }

--- a/webapp/webannotation/src/main/java/module-info.java
+++ b/webapp/webannotation/src/main/java/module-info.java
@@ -26,12 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.webapp.webannotation {
+module cloud.piranha.webapp.webservlet {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+
     requires java.annotation;
     requires java.logging;
-
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
 
     exports cloud.piranha.webapp.webservlet;
 }

--- a/webapp/webannotation/src/main/java/module-info.java
+++ b/webapp/webannotation/src/main/java/module-info.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module cloud.piranha.webapp.webservlet {
+module cloud.piranha.webapp.webannotation {
     requires cloud.piranha.servlet.api;
     requires cloud.piranha.webapp.api;
 

--- a/webapp/webxml/src/main/java/module-info.java
+++ b/webapp/webxml/src/main/java/module-info.java
@@ -26,16 +26,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-module piranha.webapp.webxml {
+module cloud.piranha.webapp.webxml {
+    requires cloud.piranha.servlet.api;
+    requires cloud.piranha.webapp.api;
+    requires cloud.piranha.webapp.impl;
+
     requires java.logging;
     requires java.xml;
-
-    requires piranha.servlet.api;
-    requires piranha.webapp.api;
-    requires piranha.webapp.impl;
 
     exports cloud.piranha.webapp.webxml;
 
     // Tests
-    requires static piranha.resource;
+    requires static cloud.piranha.resource;
 }


### PR DESCRIPTION
Fixes #1059 

Significant changes (due artifactId not being the same as the package):

_piranha.extension.micro.core_ -> _cloud.piranha.micro.core_
_piranha.micro.maven.plugin_ -> _cloud.piranha.maven.plugins.micro_
_piranha.microprofile.omnifaces.jwt_ -> _cloud.piranha.omnifaces.jwt_
_piranha.webapp.webannotation_ -> _cloud.piranha.webapp.webservlet_