### PR TITLE
Fixes issue #1156 - Prefix servlet mapping is matching wrong requests

### DIFF
--- a/webapp/impl/src/main/java/cloud/piranha/webapp/impl/DefaultWebApplicationRequestMapper.java
+++ b/webapp/impl/src/main/java/cloud/piranha/webapp/impl/DefaultWebApplicationRequestMapper.java
@@ -289,10 +289,8 @@ public class DefaultWebApplicationRequestMapper implements WebApplicationRequest
             String prefix = prefixes.nextElement();
             if (!prefix.startsWith("*.") && prefix.endsWith("/*")) {
                 prefix = prefix.substring(0, prefix.length() - 1);
-                if (path.startsWith(prefix)) {
-                    if (result == null) {
-                        result = new DefaultWebApplicationRequestMapping(prefix);
-                    }
+                if ((path + "/").startsWith(prefix)) {
+                    result = new DefaultWebApplicationRequestMapping(prefix);
                     break;
                 }
             }

--- a/webapp/impl/src/test/java/cloud/piranha/webapp/impl/DefaultWebApplicationRequestMapperTest.java
+++ b/webapp/impl/src/test/java/cloud/piranha/webapp/impl/DefaultWebApplicationRequestMapperTest.java
@@ -111,6 +111,45 @@ class DefaultWebApplicationRequestMapperTest {
     }
 
     /**
+     * Test findServletPrefixMatch method.
+     *
+     * @throws Exception
+     */
+    @Test
+    void testFindPrefixServletMatch4() throws Exception {
+        DefaultWebApplicationRequestMapper webAppRequestMapper = new DefaultWebApplicationRequestMapper();
+        DefaultWebApplication webApp = new DefaultWebApplication();
+        webApp.setWebApplicationRequestMapper(webAppRequestMapper);
+        webApp.addServlet("echo", new TestEcho1Servlet());
+        webApp.addServletMapping("echo", "/echo/*");
+        webApp.initialize();
+        webApp.start();
+        TestWebApplicationRequest request = new TestWebApplicationRequest();
+        request.setServletPath("/echo");
+        TestWebApplicationResponse response = new TestWebApplicationResponse();
+        response.setBodyOnly(true);
+        webApp.service(request, response);
+        assertEquals("ECHO", new String(response.getResponseBytes()));
+    }
+
+    @Test
+    void testFindPrefixServletMatch5() throws Exception {
+        DefaultWebApplicationRequestMapper webAppRequestMapper = new DefaultWebApplicationRequestMapper();
+        DefaultWebApplication webApp = new DefaultWebApplication();
+        webApp.setWebApplicationRequestMapper(webAppRequestMapper);
+        webApp.addServlet("echo", new TestEcho1Servlet());
+        webApp.addServletMapping("echo", "/echo/*");
+        webApp.initialize();
+        webApp.start();
+        TestWebApplicationRequest request = new TestWebApplicationRequest();
+        request.setServletPath("/echo2");
+        TestWebApplicationResponse response = new TestWebApplicationResponse();
+        response.setBodyOnly(true);
+        webApp.service(request, response);
+        assertEquals(404, response.getStatus());
+    }
+
+    /**
      * Test findExtensionServletMatch method.
      *
      * @throws Exception


### PR DESCRIPTION
Fixes #1156 

Fix regression not allowing requests without an ending slash