### PR TITLE
Fixes issue #1228 - Start Piranha Server using JPMS by default

### DIFF
--- a/pages/jasper/src/main/java/cloud/piranha/pages/jasper/JasperInitializer.java
+++ b/pages/jasper/src/main/java/cloud/piranha/pages/jasper/JasperInitializer.java
@@ -132,4 +132,12 @@ public class JasperInitializer implements ServletContainerInitializer {
 
         LOGGER.fine("Initialized Jasper integration");
     }
+
+    static {
+        // This is a hack until Jasper handles JPMS
+        if (JasperInitializer.class.getModule().isNamed()) {
+            String oldExtDirs = System.getProperty("java.ext.dirs", "");
+            System.setProperty("java.ext.dirs", System.getProperty("jdk.module.path") + pathSeparator + oldExtDirs);
+        }
+    }
 }

--- a/server/src/main/zip/bin/run.sh
+++ b/server/src/main/zip/bin/run.sh
@@ -10,7 +10,13 @@ else
     JAVA_BIN=${JAVA_HOME}/bin/java
 fi
 
-exec ${JAVA_BIN} ${JAVA_ARGS} -Djava.util.logging.config.file=etc/logging.properties -jar lib/piranha-server.jar &
+if [[ "${PIRANHA_JPMS}" == "false" ]]; then
+    INIT_OPTIONS="-jar lib/piranha-server.jar"
+else
+    INIT_OPTIONS="--module-path lib -m cloud.piranha.server"
+fi
+
+exec ${JAVA_BIN} ${JAVA_ARGS} -Djava.util.logging.config.file=etc/logging.properties ${INIT_OPTIONS} &
 
 PID=$!
 echo $PID >> tmp/piranha.pid

--- a/server/src/main/zip/bin/start.sh
+++ b/server/src/main/zip/bin/start.sh
@@ -10,6 +10,12 @@ else
     JAVA_BIN=${JAVA_HOME}/bin/java
 fi
 
+if [[ "${PIRANHA_JPMS}" == "false" ]]; then
+    INIT_OPTIONS="-jar lib/piranha-server.jar"
+else
+    INIT_OPTIONS="--module-path lib -m cloud.piranha.server"
+fi
+
 #
 # Turn SSL on.
 #
@@ -31,7 +37,7 @@ fi
 # SSL_KEY_STORE_PASSWORD=-Djavax.net.ssl.keyStorePassword=password
 
 ${JAVA_BIN} ${JAVA_ARGS} ${SSL_DEBUG} ${SSL_KEY_STORE} ${SSL_KEY_STORE_PASSWORD} \
-  -Djava.util.logging.config.file=etc/logging.properties -jar \
-  lib/piranha-server.jar ${SSL_ON} &
+  -Djava.util.logging.config.file=etc/logging.properties \
+  ${INIT_OPTIONS} ${SSL_ON} &
 
 echo $! >> tmp/piranha.pid


### PR DESCRIPTION
Fixes #1228 

It was needed to set the java.ext.dirs property because the Jasper cannot find the classes by setting the classpath to jdk.module.path. 
However, the jdk.module.path property contains only "lib" and the Jasper only understands all jars specified (no wildcard or directories).
By settings the java.ext.dirs property, we can supply the folder directly to javac compiler.