### PR TITLE
Fixes issue #1235 - Run TCK using JDK 8

### DIFF
--- a/.github/workflows/ext-tck-pages.yml
+++ b/.github/workflows/ext-tck-pages.yml
@@ -9,14 +9,20 @@ jobs:
       matrix:
         java: [ '15' ]
         os: [ubuntu-latest]
+        jdk-tck: ['8', '15']
     steps:
     - name: Checkout sources
       uses: actions/checkout@v1
-    - name: Set up Java
+    - name: Set up Java ${{ matrix.jdk-tck }} for running TCK
+      id: set-java-tck
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jdk-tck }}
+    - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
     - name: Setup for TCK
       run: mvn -B -DskipTests=true install
     - name: Run TCK
-      run: mvn -amd -B -P external -pl external/tck/pages verify
+      run: mvn -amd -B -P external -pl external/tck/pages -Dant.java.home=${{ steps.set-java-tck.outputs.path }} verify

--- a/.github/workflows/ext-tck-servlet.yml
+++ b/.github/workflows/ext-tck-servlet.yml
@@ -9,14 +9,20 @@ jobs:
       matrix:
         java: [ '15' ]
         os: [ubuntu-latest]
+        jdk-tck: ['8', '15']
     steps:
     - name: Checkout sources
       uses: actions/checkout@v1
-    - name: Set up Java
+    - name: Set up Java ${{ matrix.jdk-tck }} for running TCK
+      id: set-java-tck
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jdk-tck }}
+    - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
     - name: Setup for TCK
       run: mvn -B -DskipTests=true install
     - name: Run TCK
-      run: mvn -amd -B -P external -pl external/tck/servlet verify
+      run: mvn -amd -B -P external -pl external/tck/servlet -Dant.java.home=${{ steps.set-java-tck.outputs.path }} verify

--- a/external/tck/pages/pom.xml
+++ b/external/tck/pages/pom.xml
@@ -71,7 +71,7 @@
                                                byline="true"/>
                                 <replaceregexp file="${tck.home}/bin/ts.jte"
                                                match="sigTestClasspath=="
-                                               replace="sigTestClasspath=${el.classes}${pathsep}${jspservlet.classes}${pathsep}${JAVA_HOME}/jre/lib/rt.jar"
+                                               replace="sigTestClasspath=${el.classes}${pathsep}${jspservlet.classes}${pathsep}${ant.java.home}/jre/lib/rt.jar"
                                                byline="true"/>
                                 
                                 <!-- copy Piranha script into the TCK -->
@@ -120,6 +120,7 @@
                                     <arg value="-Dwork.dir=${signature.home}/work"/>
                                     <arg value="-Dreport.dir=${signature.home}/report"/>
                                     <arg value="runclient"/>
+                                    <env key="JAVA_HOME" value="${ant.java.home}" />
                                 </exec>
                             </target>
                         </configuration>
@@ -168,6 +169,7 @@
                                     <arg value="-Dwork.dir=${piranha.home}/work"/>
                                     <arg value="-Dreport.dir=${piranha.home}/report"/>
                                     <arg value="runclient"/>
+                                    <env key="JAVA_HOME" value="${ant.java.home}" />
                                 </exec>
                             </target>
                         </configuration>
@@ -263,6 +265,7 @@
     
     <properties>
         <ant.home>${project.build.directory}/ant</ant.home>
+        <ant.java.home>${java.home}</ant.java.home>
         <piranha.home>${project.build.directory}/piranha</piranha.home>
         <signature.home>${project.build.directory}/signature</signature.home>
         <tck.home>${project.build.directory}/tck</tck.home>

--- a/external/tck/servlet/pom.xml
+++ b/external/tck/servlet/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
         <ant.home>${project.build.directory}/ant</ant.home>
+        <ant.java.home>${java.home}</ant.java.home>
         <piranha.home>${project.build.directory}/piranha</piranha.home>
         <signature.home>${project.build.directory}/signature</signature.home>
         <tck.home>${project.build.directory}/tck</tck.home>
@@ -84,10 +85,10 @@
                                                        replace="servlet\.classes=${signature.home}/piranha-servlet-api.jar"
                                                        byline="true"/>
                                         
-                                        <!-- remove java.endorsed.dirs by \ -->
+                                        <!-- remove java.endorsed.dirs by Xbootclasspath -->
                                         <replaceregexp file="${tck.home}/bin/ts.jte"
                                                        match="\s+-Djava\.endorsed\.dirs=(.*)"
-                                                       replace="\\\"
+                                                       replace="-Xbootclasspath/a:${tck.home}/endorsedlib/flow\.jar \\\"
                                                        byline="true"/>
                                 
                                         <!-- copy Piranha script into the TCK -->
@@ -137,6 +138,7 @@
                                             <arg value="-Dwork.dir=${signature.home}/work"/>
                                             <arg value="-Dreport.dir=${signature.home}/report"/>
                                             <arg value="runclient"/>
+                                            <env key="JAVA_HOME" value="${ant.java.home}" />
                                         </exec>
                                     </target>
                                 </configuration>
@@ -173,11 +175,12 @@
                                 <configuration>
                                     <target>
                                         <!-- run all the tests -->
-                                        <exec executable="${ant.home}/bin/ant" 
+                                        <exec executable="${ant.home}/bin/ant"
                                               dir="${test.home}">
                                             <arg value="-Dwork.dir=${piranha.home}/work"/>
                                             <arg value="-Dreport.dir=${piranha.home}/report"/>
                                             <arg value="runclient"/>
+                                            <env key="JAVA_HOME" value="${ant.java.home}" />
                                         </exec>
                                     </target>
                                 </configuration>


### PR DESCRIPTION
Fixes #1235

I have changed from endorsed lib to Xbootclasspath/a to be able to run the TCK with both JDK 8 and 15.
Unfortunately, the setup-java only exposes the JAVA_HOME pointing to the JDK 8 with version, so I had to fix the JDK 8 version to the 265 to avoid having to change the pom.xml each new release of JDK 8.