### PR TITLE
Fixes issue #1247 - Copy attributes from the session manager to the session cookie

### DIFF
--- a/test/snoop/pom.xml
+++ b/test/snoop/pom.xml
@@ -19,8 +19,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
+            <groupId>cloud.piranha.servlet</groupId>
+            <artifactId>piranha-servlet-api</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/test/vaadin/pom.xml
+++ b/test/vaadin/pom.xml
@@ -30,8 +30,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
+            <groupId>cloud.piranha.servlet</groupId>
+            <artifactId>piranha-servlet-api</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/webapp/impl/src/main/java/cloud/piranha/webapp/impl/DefaultHttpSessionManager.java
+++ b/webapp/impl/src/main/java/cloud/piranha/webapp/impl/DefaultHttpSessionManager.java
@@ -143,6 +143,7 @@ public class DefaultHttpSessionManager implements HttpSessionManager, SessionCoo
         name = "JSESSIONID";
         sessionListeners = new ArrayList<>(1);
         sessionTimeout = 10;
+        maxAge = -1;
         sessions = new ConcurrentHashMap<>();
     }
 
@@ -161,6 +162,12 @@ public class DefaultHttpSessionManager implements HttpSessionManager, SessionCoo
         } else {
             cookie.setPath("".equals(webApplication.getContextPath()) ? "/" : webApplication.getContextPath());
         }
+
+        cookie.setComment(comment);
+        cookie.setDomain(domain);
+        cookie.setHttpOnly(httpOnly);
+        cookie.setMaxAge(maxAge);
+        cookie.setSecure(secure);
 
         response.addCookie(cookie);
 


### PR DESCRIPTION
Fixes #1247 

There is some discussion about the default value of _getName()_ in https://github.com/eclipse-ee4j/jakartaee-tck/pull/567.
We may need to revisit it later.