### PR TITLE
Fixes issue #1266 - Add HTTP/2 support for Grizzly

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -86,7 +86,17 @@
                 <groupId>org.glassfish.grizzly</groupId>
                 <artifactId>grizzly-http-server</artifactId>
                 <version>2.4.4</version>
-            </dependency>        
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.grizzly</groupId>
+                <artifactId>grizzly-http2</artifactId>
+                <version>2.4.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.grizzly</groupId>
+                <artifactId>grizzly-npn-api</artifactId>
+                <version>1.9</version>
+            </dependency>
 
             <!-- H2 database -->
             <dependency>

--- a/http/grizzly/pom.xml
+++ b/http/grizzly/pom.xml
@@ -33,6 +33,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-http2</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-npn-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/http/grizzly/src/main/java/cloud/piranha/http/grizzly/GrizzlyHttpServer.java
+++ b/http/grizzly/src/main/java/cloud/piranha/http/grizzly/GrizzlyHttpServer.java
@@ -37,8 +37,10 @@ import java.util.logging.Logger;
 import org.glassfish.grizzly.CompletionHandler;
 import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.grizzly.http.server.Response;
+import org.glassfish.grizzly.http2.Http2AddOn;
 
 import cloud.piranha.http.api.HttpServerProcessor;
 
@@ -139,7 +141,9 @@ public class GrizzlyHttpServer implements cloud.piranha.http.api.HttpServer {
     public void start() {
         if (httpServer == null) {
             httpServer = HttpServer.createSimpleServer(null, port);
-            httpServer.getListener("grizzly").setSecure(ssl);
+            NetworkListener networkListener = httpServer.getListener("grizzly");
+            networkListener.setSecure(ssl);
+            networkListener.registerAddOn(new Http2AddOn());
         }
         addHttpHandler();
         try {

--- a/http/grizzly/src/main/java/module-info.java
+++ b/http/grizzly/src/main/java/module-info.java
@@ -39,6 +39,7 @@ module cloud.piranha.http.grizzly {
     requires grizzly.framework;
     requires grizzly.http;
     requires grizzly.http.server;
+    requires grizzly.http2;
 
     provides HttpServer with GrizzlyHttpServer;
 }


### PR DESCRIPTION
Fixes #1266 
For now, only HTTP/2 via cleartext (h2c) will be supported due to https://github.com/eclipse-ee4j/grizzly/pull/2103