### PR TITLE
Fixes issue #1287 - Add weekly pipeline to run the Servlet TCK for all the HTTP implementations

### DIFF
--- a/.github/workflows/ext-tck-servlet-all-http-impls.yml
+++ b/.github/workflows/ext-tck-servlet-all-http-impls.yml
@@ -1,7 +1,7 @@
-name: ext-tck-servlet
+name: ext-tck-servlet-all-http-impls
 on:
   schedule:
-  - cron: "0 8 * * *"
+  - cron: "0 8 * * 5"
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -10,6 +10,7 @@ jobs:
         java: [ '15' ]
         os: [ubuntu-latest]
         jdk-tck: ['8', '15']
+        http: ['grizzly', 'impl', 'jdk', 'undertow']
     steps:
     - name: Checkout sources
       uses: actions/checkout@v1
@@ -23,6 +24,6 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
     - name: Setup for TCK
-      run: mvn -B -DskipTests=true install
+      run: mvn -B -DskipTests=true -P${{ matrix.http }} install
     - name: Run TCK
       run: mvn -amd -B -P external -pl external/tck/servlet -Dant.java.home=${{ steps.set-java-tck.outputs.path }} verify


### PR DESCRIPTION
Fixes #1287 

Probably a better name will be needed for the new pipeline.
Should I include the Netty implementation? If so, the build will be marked as failed because we need to find out why it is not being able to complete the TCK.