### PR TITLE
Fixes issue #1737 - Include only runtime dependencies in Piranha CLI

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -60,6 +60,9 @@
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Fixes #1737 