### PR TITLE
#2363 Split out AuthorizationPostInitializer

### DIFF
--- a/extension/exousia/src/main/java/cloud/piranha/extension/exousia/AuthorizationPostInitializer.java
+++ b/extension/exousia/src/main/java/cloud/piranha/extension/exousia/AuthorizationPostInitializer.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2002-2022 Manorrock.com. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package cloud.piranha.extension.exousia;
+
+import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.CONSTRAINTS;
+import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.PERROLE_PERMISSIONS;
+import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.SECURITY_ANNOTATIONS;
+import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.SECURITY_ELEMENTS;
+import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.UNCHECKED_PERMISSIONS;
+import static java.util.Collections.disjoint;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toSet;
+import static org.glassfish.exousia.constraints.SecurityConstraint.join;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.glassfish.exousia.AuthorizationService;
+import org.glassfish.exousia.constraints.SecurityConstraint;
+import org.glassfish.exousia.constraints.WebResourceCollection;
+import org.glassfish.exousia.mapping.SecurityRoleRef;
+
+import cloud.piranha.core.api.WebApplication;
+import cloud.piranha.core.api.WebXmlManager;
+import jakarta.security.jacc.PolicyConfiguration;
+import jakarta.security.jacc.PolicyContextException;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+
+/**
+ * The Exousia initializer.
+ *
+ * @author Arjan Tijms
+ */
+public class AuthorizationPostInitializer implements ServletContainerInitializer {
+
+    /**
+     * Stores the Piranha to Exousia converter.
+     */
+    PiranhaToExousiaConverter piranhaToExousiaConverter = new PiranhaToExousiaConverter();
+
+    /**
+     * Initialize Exousia
+     *
+     * @param classes the classes.
+     * @param servletContext the Servlet context.
+     * @throws ServletException when a Servlet error occurs.
+     */
+    @Override
+    public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
+        WebApplication context = (WebApplication) servletContext;
+
+        // Get the main (Exousia) authorization service, which implements the various entry points (an SPI)
+        // for a runtime to make use of Jakarta Authorization
+        AuthorizationService authorizationService = getAuthorizationService(context);
+
+        // Join together in one list the constraints set by the servlet security elements, and the
+        // piranha specific security constraint
+        List<SecurityConstraint> securityConstraints = getAllScurityConstraints(context);
+
+        for (SecurityConstraint securityConstraint : securityConstraints) {
+            context.getManager().getSecurityManager().declareRoles(securityConstraint.getRolesAllowed());
+        }
+
+        if (hasPermissionsSet(context)) {
+            setPermissions(context, authorizationService);
+        } else {
+            setConstraints(context, authorizationService, securityConstraints);
+        }
+
+        authorizationService.commitPolicy();
+
+        addAuthorizationPreFilter(context);
+    }
+
+
+    // ### Private methods
+
+
+    private AuthorizationService getAuthorizationService(WebApplication context) throws ServletException {
+        return getAttribute(context, AuthorizationPreInitializer.AUTHZ_SERVICE);
+    }
+
+    private List<SecurityConstraint> getAllScurityConstraints(WebApplication context) throws ServletException {
+        List<SecurityConstraint> webXmlConstraints = getConstraintsFromWebXml(context);
+        List<SecurityConstraint> annotationConstraints = filterAnnotatedConstraints(
+                webXmlConstraints,
+                getConstraintsFromSecurityAnnotations(context));
+
+        List<SecurityConstraint> allScurityConstraints = join(
+            getConstraintsFromSecurityElements(context),
+            annotationConstraints,
+            getOptionalAttribute(context, CONSTRAINTS),
+            webXmlConstraints);
+
+        if (allScurityConstraints == null) {
+            return emptyList();
+        }
+
+        return allScurityConstraints;
+    }
+
+    private void addAuthorizationPreFilter(WebApplication context) {
+        FilterRegistration.Dynamic dynamic = context.addFilter(AuthorizationPreFilter.class.getSimpleName(), AuthorizationPreFilter.class);
+        dynamic.setAsyncSupported(true);
+        context.addFilterMapping(AuthorizationPreFilter.class.getSimpleName(), "/*");
+    }
+
+    private List<SecurityConstraint> filterAnnotatedConstraints(List<SecurityConstraint> webXmlConstraints, List<SecurityConstraint> annotationConstraints) {
+        if (isAnyNull(webXmlConstraints, annotationConstraints)) {
+            return annotationConstraints;
+        }
+
+        // Servlet Spec 13.4.1
+        //
+        // When a security-constraint in the portable deployment descriptor includes a url-pattern
+        // that is an exact match for a pattern mapped to a class annotated with @ServletSecurity,
+        // the annotation must have no effect on the constraints enforced by the Servlet container
+        // on the pattern.
+
+        // Index all URL patterns in web.xml
+        Set<String> webXmlUrlPatterns = webXmlConstraints
+            .stream()
+            .flatMap(e -> e.getWebResourceCollections().stream())
+            .flatMap(e -> e.getUrlPatterns().stream())
+            .collect(toSet())
+            ;
+
+        List<SecurityConstraint> filteredAnnotationConstraints = new ArrayList<>();
+        for (SecurityConstraint annotationConstraint : annotationConstraints) {
+            List<WebResourceCollection> webResourceCollections = new ArrayList<>();
+            for (WebResourceCollection webResourceCollection : annotationConstraint.getWebResourceCollections()) {
+                WebResourceCollection newWebResourceCollection = webResourceCollection;
+                if (!disjoint(webXmlUrlPatterns, webResourceCollection.getUrlPatterns())) {
+                    Set<String> complementPatterns = new HashSet<>(webResourceCollection.getUrlPatterns());
+                    complementPatterns.removeAll(webXmlUrlPatterns);
+
+                    if (complementPatterns.isEmpty()) {
+                        newWebResourceCollection = null;
+                    } else {
+                        newWebResourceCollection = new WebResourceCollection(
+                            complementPatterns,
+                            webResourceCollection.getHttpMethods(),
+                            webResourceCollection.getHttpMethodOmissions());
+                    }
+                }
+
+                if (newWebResourceCollection != null) {
+                    webResourceCollections.add(newWebResourceCollection);
+                }
+            }
+
+            if (!webResourceCollections.isEmpty()) {
+                filteredAnnotationConstraints.add(new SecurityConstraint(
+                        webResourceCollections,
+                        annotationConstraint.getRolesAllowed(),
+                        annotationConstraint.getTransportGuarantee()));
+            }
+        }
+
+        return filteredAnnotationConstraints;
+    }
+
+    /**
+     * Get the security constraints from security elements.
+     *
+     * @param servletContext the Servlet context.
+     * @return the list of security constraints.
+     */
+    private List<SecurityConstraint> getConstraintsFromSecurityElements(ServletContext servletContext) {
+        return piranhaToExousiaConverter.getConstraintsFromSecurityElements(getOptionalAttribute(servletContext, SECURITY_ELEMENTS));
+    }
+
+    /**
+     * Get the security constraints from annotations.
+     *
+     * @param servletContext the Servlet context.
+     * @return the list of security constraints.
+     */
+    private List<SecurityConstraint> getConstraintsFromSecurityAnnotations(ServletContext servletContext) {
+        return piranhaToExousiaConverter.getConstraintsFromSecurityAnnotations(getOptionalAttribute(servletContext, SECURITY_ANNOTATIONS));
+    }
+
+    /**
+     * Get security constraints from web.xml.
+     *
+     * @param webApplication the web application.
+     * @return the list of security constraints.
+     * @throws ServletException when a Servlet error occurs.
+     */
+    private List<SecurityConstraint> getConstraintsFromWebXml(WebApplication webApplication) throws ServletException {
+        WebXmlManager manager = webApplication.getManager().getWebXmlManager();
+        return piranhaToExousiaConverter.getConstraintsFromWebXml(manager.getWebXml());
+    }
+
+    /**
+     * Get the security role refs from web.xml.
+     *
+     * @param webApplication the web application.
+     * @return the map of security role refs.
+     * @throws ServletException when a Servlet error occurs.
+     */
+    public Map<String, List<SecurityRoleRef>> getSecurityRoleRefsFromWebXml(WebApplication webApplication) throws ServletException {
+        WebXmlManager manager = webApplication.getManager().getWebXmlManager();
+        return piranhaToExousiaConverter.getSecurityRoleRefsFromWebXml(webApplication.getServletRegistrations().keySet(), manager.getWebXml());
+    }
+
+
+
+
+    private boolean hasPermissionsSet(ServletContext servletContext) {
+        return getOptionalAttribute(servletContext, UNCHECKED_PERMISSIONS) != null
+                || getOptionalAttribute(servletContext, PERROLE_PERMISSIONS) != null;
+    }
+
+    private void setPermissions(ServletContext servletContext, AuthorizationService authorizationService) {
+        // Add permissions to the policy configuration, which is the repository that the policy (authorization module)
+        // uses
+        PolicyConfiguration policyConfiguration = authorizationService.getPolicyConfiguration();
+
+        try {
+            List<Permission> unchecked = getOptionalAttribute(servletContext, UNCHECKED_PERMISSIONS);
+            if (unchecked != null) {
+                for (Permission permission : unchecked) {
+                    policyConfiguration.addToUncheckedPolicy(permission);
+                }
+            }
+
+            List<Entry<String, Permission>> perRole = getOptionalAttribute(servletContext, PERROLE_PERMISSIONS);
+            if (perRole != null) {
+                for (Entry<String, Permission> perRoleEntry : perRole) {
+                    policyConfiguration.addToRole(perRoleEntry.getKey(), perRoleEntry.getValue());
+                }
+            }
+        } catch (PolicyContextException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void setConstraints(WebApplication context, AuthorizationService authorizationService, List<SecurityConstraint> securityConstraints) throws ServletException {
+        authorizationService.addConstraintsToPolicy(
+            securityConstraints,
+            context.getManager().getSecurityManager().getRoles(),
+            context.getManager().getSecurityManager().getDenyUncoveredHttpMethods(),
+            getSecurityRoleRefsFromWebXml(context));
+    }
+
+
+
+    // ### Utility methods
+
+    private static <T> T getAttribute(ServletContext servletContext, String name) throws ServletException {
+        T t = getOptionalAttribute(servletContext, name);
+        if (t == null) {
+            throw new ServletException("Attribute " + name + " not specified");
+        }
+
+        return t;
+    }
+
+    private static  <T> T getOptionalAttribute(ServletContext servletContext, String name) {
+        @SuppressWarnings("unchecked")
+        T t = (T) servletContext.getAttribute(name);
+
+        return t;
+    }
+
+    private static boolean isAnyNull(Object... values) {
+        for (Object value : values) {
+            if (value == null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/extension/micro/src/main/java/cloud/piranha/extension/micro/MicroExtension.java
+++ b/extension/micro/src/main/java/cloud/piranha/extension/micro/MicroExtension.java
@@ -27,12 +27,16 @@
  */
 package cloud.piranha.extension.micro;
 
+import static java.util.Arrays.asList;
+
 import cloud.piranha.core.api.WebApplication;
 import cloud.piranha.core.api.WebApplicationExtension;
 import cloud.piranha.core.api.WebApplicationExtensionContext;
 import cloud.piranha.extension.apache.fileupload.ApacheMultiPartExtension;
+import cloud.piranha.extension.exousia.AuthorizationPostInitializer;
 import cloud.piranha.extension.herring.HerringExtension;
 import cloud.piranha.extension.security.jakarta.JakartaSecurityAllInitializer;
+import cloud.piranha.extension.security.jakarta.JakartaSecurityExtension;
 import cloud.piranha.extension.security.servlet.ServletSecurityManagerExtension;
 import cloud.piranha.extension.standard.async.StandardAsyncExtension;
 import cloud.piranha.extension.standard.localeencoding.StandardLocaleEncodingExtension;
@@ -43,8 +47,8 @@ import cloud.piranha.extension.standard.servletannotations.StandardServletAnnota
 import cloud.piranha.extension.standard.tempdir.StandardTempDirExtension;
 import cloud.piranha.extension.standard.webxml.StandardWebXmlExtension;
 import cloud.piranha.extension.standard.welcomefile.StandardWelcomeFileExtension;
+import cloud.piranha.extension.wasp.WaspExtension;
 import cloud.piranha.extension.wasp.WaspInitializer;
-import static java.util.Arrays.asList;
 
 /**
  * The default {@link WebApplicationExtension} used to configure a web application for Piranha Micro.
@@ -77,5 +81,6 @@ public class MicroExtension implements WebApplicationExtension {
         new StandardServletContainerInitializerExtension(
             true, asList("org.glassfish.soteria.servlet.SamRegistrationInstaller"))
             .configure(webApplication);
+        webApplication.addInitializer(new AuthorizationPostInitializer());
     }
 }

--- a/extension/micro/src/main/java/cloud/piranha/extension/micro/MicroExtension.java
+++ b/extension/micro/src/main/java/cloud/piranha/extension/micro/MicroExtension.java
@@ -36,7 +36,6 @@ import cloud.piranha.extension.apache.fileupload.ApacheMultiPartExtension;
 import cloud.piranha.extension.exousia.AuthorizationPostInitializer;
 import cloud.piranha.extension.herring.HerringExtension;
 import cloud.piranha.extension.security.jakarta.JakartaSecurityAllInitializer;
-import cloud.piranha.extension.security.jakarta.JakartaSecurityExtension;
 import cloud.piranha.extension.security.servlet.ServletSecurityManagerExtension;
 import cloud.piranha.extension.standard.async.StandardAsyncExtension;
 import cloud.piranha.extension.standard.localeencoding.StandardLocaleEncodingExtension;
@@ -47,7 +46,6 @@ import cloud.piranha.extension.standard.servletannotations.StandardServletAnnota
 import cloud.piranha.extension.standard.tempdir.StandardTempDirExtension;
 import cloud.piranha.extension.standard.webxml.StandardWebXmlExtension;
 import cloud.piranha.extension.standard.welcomefile.StandardWelcomeFileExtension;
-import cloud.piranha.extension.wasp.WaspExtension;
 import cloud.piranha.extension.wasp.WaspInitializer;
 
 /**
@@ -70,8 +68,6 @@ public class MicroExtension implements WebApplicationExtension {
         context.add(StandardWebXmlExtension.class);
         context.add(StandardServletAnnotationsExtension.class);
         context.add(HerringExtension.class);
-        context.add(JakartaSecurityExtension.class);
-        context.add(WaspExtension.class);
     }
 
     @Override

--- a/extension/micro/src/main/java/cloud/piranha/extension/micro/MicroExtension.java
+++ b/extension/micro/src/main/java/cloud/piranha/extension/micro/MicroExtension.java
@@ -66,6 +66,8 @@ public class MicroExtension implements WebApplicationExtension {
         context.add(StandardWebXmlExtension.class);
         context.add(StandardServletAnnotationsExtension.class);
         context.add(HerringExtension.class);
+        context.add(JakartaSecurityExtension.class);
+        context.add(WaspExtension.class);
     }
 
     @Override

--- a/extension/micro/src/main/java/module-info.java
+++ b/extension/micro/src/main/java/module-info.java
@@ -46,4 +46,5 @@ module cloud.piranha.extension.micro {
     requires cloud.piranha.extension.standard.welcomefile;
     requires cloud.piranha.extension.wasp;
     requires cloud.piranha.core.api;
+    requires cloud.piranha.extension.exousia;
 }

--- a/extension/security-jakarta/src/main/java/cloud/piranha/extension/security/jakarta/JakartaSecurityAllInitializer.java
+++ b/extension/security-jakarta/src/main/java/cloud/piranha/extension/security/jakarta/JakartaSecurityAllInitializer.java
@@ -27,9 +27,17 @@
  */
 package cloud.piranha.extension.security.jakarta;
 
+import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.AUTHZ_FACTORY_CLASS;
+import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.AUTHZ_POLICY_CLASS;
+
 import java.util.Set;
 
-import cloud.piranha.extension.security.servlet.ServletSecurityAllInitializer;
+import org.glassfish.exousia.modules.def.DefaultPolicy;
+import org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory;
+
+import cloud.piranha.extension.eleos.AuthenticationInitializer;
+import cloud.piranha.extension.exousia.AuthorizationInitializer;
+import cloud.piranha.extension.exousia.AuthorizationPreInitializer;
 import cloud.piranha.extension.soteria.SoteriaInitializer;
 import cloud.piranha.extension.soteria.SoteriaPreCDIInitializer;
 import cloud.piranha.extension.weld.WeldInitializer;
@@ -51,14 +59,21 @@ public class JakartaSecurityAllInitializer implements ServletContainerInitialize
 
         // Makes web.xml login-config available to Soteria
         new SoteriaPreCDIInitializer(),
-        
-        // Initializes the Servlet Security primitives, on which Jakarta Security is based
-        new ServletSecurityAllInitializer(),
+
+        // Configures the security constraints, authorization module
+        // and authorization filter that checks constraints before authentication
+        new AuthorizationPreInitializer(),
+
+        // Configures the authentication module and authentication filter
+        new AuthenticationInitializer(),
+
+        // Configures the authorization filter that checks constraints after authentication
+        new AuthorizationInitializer(),
 
         // Initializes CDI, on which Jakarta Security is also based
         new WeldInitializer(),
 
-        // Configures Soteria, which implements Jakarta Security and sets itself as a Servlet 
+        // Configures Soteria, which implements Jakarta Security and sets itself as a Servlet
         // authentication module
         new SoteriaInitializer(),
     };
@@ -72,6 +87,9 @@ public class JakartaSecurityAllInitializer implements ServletContainerInitialize
      */
     @Override
     public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
+        servletContext.setAttribute(AUTHZ_FACTORY_CLASS, DefaultPolicyConfigurationFactory.class);
+        servletContext.setAttribute(AUTHZ_POLICY_CLASS, DefaultPolicy.class);
+
         for (ServletContainerInitializer initializer : initializers) {
             initializer.onStartup(classes, servletContext);
         }

--- a/extension/security-jakarta/src/main/java/cloud/piranha/extension/security/jakarta/JakartaSecurityExtension.java
+++ b/extension/security-jakarta/src/main/java/cloud/piranha/extension/security/jakarta/JakartaSecurityExtension.java
@@ -27,14 +27,13 @@
  */
 package cloud.piranha.extension.security.jakarta;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.System.Logger.Level;
-import java.lang.System.Logger;
+import static java.lang.System.Logger.Level.WARNING;
 
-import jakarta.servlet.ServletContainerInitializer;
+import java.lang.System.Logger;
 
 import cloud.piranha.core.api.WebApplication;
 import cloud.piranha.core.api.WebApplicationExtension;
+import jakarta.servlet.ServletContainerInitializer;
 
 /**
  * The extension for Jakarta Security.
@@ -56,17 +55,15 @@ public class JakartaSecurityExtension implements WebApplicationExtension {
     @Override
     public void configure(WebApplication webApplication) {
         try {
-            ClassLoader classLoader = webApplication.getClassLoader();
-            Class<? extends ServletContainerInitializer> clazz
-                    = classLoader.
-                    loadClass(JakartaSecurityAllInitializer.class.getName())
-                    .asSubclass(ServletContainerInitializer.class);
-            ServletContainerInitializer initializer = clazz.getDeclaredConstructor().newInstance();
-            webApplication.addInitializer(initializer);
-        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException
-                | InstantiationException | IllegalAccessException
-                | IllegalArgumentException | InvocationTargetException ex) {
-            LOGGER.log(Level.WARNING, "Unable to enable the JakartaSecurityExtension", ex);
+            webApplication.addInitializer(
+                webApplication.getClassLoader()
+                              .loadClass(JakartaSecurityAllInitializer.class.getName())
+                              .asSubclass(ServletContainerInitializer.class)
+                              .getDeclaredConstructor()
+                              .newInstance());
+
+        } catch (ReflectiveOperationException | SecurityException | IllegalArgumentException ex) {
+            LOGGER.log(WARNING, "Unable to enable the JakartaSecurityExtension", ex);
         }
     }
 }

--- a/extension/security-servlet/src/main/java/cloud/piranha/extension/security/servlet/ServletSecurityAllInitializer.java
+++ b/extension/security-servlet/src/main/java/cloud/piranha/extension/security/servlet/ServletSecurityAllInitializer.java
@@ -37,6 +37,7 @@ import org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory;
 
 import cloud.piranha.extension.eleos.AuthenticationInitializer;
 import cloud.piranha.extension.exousia.AuthorizationInitializer;
+import cloud.piranha.extension.exousia.AuthorizationPostInitializer;
 import cloud.piranha.extension.exousia.AuthorizationPreInitializer;
 import jakarta.servlet.ServletContainerInitializer;
 import jakarta.servlet.ServletContext;
@@ -63,6 +64,10 @@ public class ServletSecurityAllInitializer implements ServletContainerInitialize
 
         // Configures the authorization filter that checks constraints after authentication
         new AuthorizationInitializer(),
+
+        // Inits the authorization server. Note this should always run after all Servlets in the application
+        // have been discovered/added.
+        new AuthorizationPostInitializer(),
     };
 
     /**

--- a/test/exousia/src/test/java/cloud/piranha/test/exousia/BasicConnectionTest.java
+++ b/test/exousia/src/test/java/cloud/piranha/test/exousia/BasicConnectionTest.java
@@ -32,6 +32,7 @@ import cloud.piranha.embedded.EmbeddedPiranhaBuilder;
 import cloud.piranha.embedded.EmbeddedRequest;
 import cloud.piranha.embedded.EmbeddedRequestBuilder;
 import cloud.piranha.embedded.EmbeddedResponse;
+import cloud.piranha.extension.exousia.AuthorizationPostInitializer;
 import cloud.piranha.extension.exousia.AuthorizationPreInitializer;
 import cloud.piranha.extension.standard.webxml.StandardWebXmlInitializer;
 import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.AUTHZ_FACTORY_CLASS;
@@ -62,28 +63,31 @@ class BasicConnectionTest {
     @Test
     void testNonSecureConnection() throws Exception {
         EmbeddedPiranha piranha = new EmbeddedPiranhaBuilder()
-                .initializer(ServletSecurityManagerInitializer.class.getName())
-                .initializer(StandardWebXmlInitializer.class.getName())
+                .initializer(ServletSecurityManagerInitializer.class)
+                .initializer(StandardWebXmlInitializer.class)
                 .attribute(AUTHZ_FACTORY_CLASS, DefaultPolicyConfigurationFactory.class)
                 .attribute(AUTHZ_POLICY_CLASS, DefaultPolicy.class)
                 .attribute(UNCHECKED_PERMISSIONS, asList(
                     new WebUserDataPermission("/*", "!GET"),
                     new WebUserDataPermission("/*", "GET:CONFIDENTIAL")))
-                .initializer(AuthorizationPreInitializer.class.getName())
-                .servlet("PublicServlet", PublicServlet.class.getName())
+                .initializer(AuthorizationPreInitializer.class)
+                .initializer(AuthorizationPostInitializer.class)
+                .servlet("PublicServlet", PublicServlet.class)
                 .servletMapping("PublicServlet", "/public/servlet")
                 .build()
                 .start();
+
         EmbeddedRequest request = new EmbeddedRequestBuilder()
                 .contextPath("")
                 .servletPath("/public/servlet")
                 .build();
         EmbeddedResponse response = new EmbeddedResponse();
+
         piranha.service(request, response);
         assertFalse(response.getResponseAsString().contains("Hello, from Servlet!"));
         piranha.stop().destroy();
     }
-    
+
     /**
      * Test basic connection permission using a secure (https) connection.
      *
@@ -99,23 +103,26 @@ class BasicConnectionTest {
                 .attribute(UNCHECKED_PERMISSIONS, asList(
                     new WebUserDataPermission("/*", "!GET"),
                     new WebUserDataPermission("/*", "GET:CONFIDENTIAL")))
-                .initializer(AuthorizationPreInitializer.class.getName())
-                .servlet("PublicServlet", PublicServlet.class.getName())
+                .initializer(AuthorizationPreInitializer.class)
+                .initializer(AuthorizationPostInitializer.class)
+                .servlet("PublicServlet", PublicServlet.class)
                 .servletMapping("PublicServlet", "/public/servlet")
                 .build()
                 .start();
+
         EmbeddedRequest request = new EmbeddedRequestBuilder()
                 .contextPath("")
                 .servletPath("/public/servlet")
                 .scheme("https")
                 .build();
         EmbeddedResponse response = new EmbeddedResponse();
+
         piranha.service(request, response);
         assertEquals(200, response.getStatus());
         assertTrue(response.getResponseAsString().contains("Hello, from Servlet!"));
         piranha.stop().destroy();
     }
-    
+
     @Test
     void testSecureConnectionExactMapping() throws Exception {
         EmbeddedPiranha piranha = new EmbeddedPiranhaBuilder()
@@ -126,17 +133,20 @@ class BasicConnectionTest {
                 .attribute(UNCHECKED_PERMISSIONS, asList(
                     new WebUserDataPermission("/public/servlet", "!GET"),
                     new WebUserDataPermission("/public/servlet", "GET:CONFIDENTIAL")))
-                .initializer(AuthorizationPreInitializer.class.getName())
-                .servlet("PublicServlet", PublicServlet.class.getName())
+                .initializer(AuthorizationPreInitializer.class)
+                .initializer(AuthorizationPostInitializer.class)
+                .servlet("PublicServlet", PublicServlet.class)
                 .servletMapping("PublicServlet", "/public/servlet")
                 .build()
                 .start();
+
         EmbeddedRequest request = new EmbeddedRequestBuilder()
                 .contextPath("")
                 .servletPath("/public/servlet")
                 .scheme("https")
                 .build();
         EmbeddedResponse response = new EmbeddedResponse();
+
         piranha.service(request, response);
         assertEquals(200, response.getStatus());
         assertTrue(response.getResponseAsString().contains("Hello, from Servlet!"));

--- a/test/soteria/basic/src/test/java/cloud/piranha/test/soteria/basic/BasicTest.java
+++ b/test/soteria/basic/src/test/java/cloud/piranha/test/soteria/basic/BasicTest.java
@@ -27,8 +27,6 @@
  */
 package cloud.piranha.test.soteria.basic;
 
-import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.AUTHZ_FACTORY_CLASS;
-import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.AUTHZ_POLICY_CLASS;
 import static cloud.piranha.extension.exousia.AuthorizationPreInitializer.CONSTRAINTS;
 import static java.util.Arrays.asList;
 import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
@@ -37,26 +35,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Base64;
 
-import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
-
-import org.junit.jupiter.api.Test;
 import org.glassfish.exousia.constraints.SecurityConstraint;
-import org.glassfish.exousia.modules.def.DefaultPolicy;
-import org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory;
+import org.junit.jupiter.api.Test;
 
-import cloud.piranha.extension.eleos.AuthenticationInitializer;
-import cloud.piranha.extension.weld.WeldInitializer;
 import cloud.piranha.embedded.EmbeddedPiranha;
 import cloud.piranha.embedded.EmbeddedPiranhaBuilder;
 import cloud.piranha.embedded.EmbeddedRequest;
 import cloud.piranha.embedded.EmbeddedRequestBuilder;
 import cloud.piranha.embedded.EmbeddedResponse;
-import cloud.piranha.extension.exousia.AuthorizationInitializer;
-import cloud.piranha.extension.exousia.AuthorizationPreInitializer;
+import cloud.piranha.extension.exousia.AuthorizationPostInitializer;
 import cloud.piranha.extension.herring.HerringExtension;
+import cloud.piranha.extension.security.jakarta.JakartaSecurityAllInitializer;
 import cloud.piranha.extension.security.servlet.ServletSecurityManagerExtension;
-import cloud.piranha.extension.soteria.SoteriaInitializer;
 import cloud.piranha.extension.standard.webxml.StandardWebXmlInitializer;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
 
 @BasicAuthenticationMechanismDefinition(realmName = "test")
 class BasicTest {
@@ -68,19 +60,14 @@ class BasicTest {
         EmbeddedPiranha piranha = new EmbeddedPiranhaBuilder()
                 .extension(ServletSecurityManagerExtension.class)
                 .extension(HerringExtension.class)
-                .initializer(StandardWebXmlInitializer.class.getName())
-                .attribute(AUTHZ_FACTORY_CLASS, DefaultPolicyConfigurationFactory.class)
-                .attribute(AUTHZ_POLICY_CLASS, DefaultPolicy.class)
+                .initializer(StandardWebXmlInitializer.class)
                 .attribute(CONSTRAINTS, asList(
                         new SecurityConstraint("/protected/servlet", "architect")))
-                .initializer(WeldInitializer.class.getName())
-                .initializer(AuthorizationPreInitializer.class.getName())
-                .initializer(AuthenticationInitializer.class.getName())
-                .initializer(AuthorizationInitializer.class.getName())
-                .initializer(SoteriaInitializer.class.getName())
-                .servlet("PublicServlet", PublicServlet.class.getName())
+                .initializer(JakartaSecurityAllInitializer.class)
+                .initializer(AuthorizationPostInitializer.class)
+                .servlet("PublicServlet", PublicServlet.class)
                 .servletMapping("PublicServlet", "/public/servlet")
-                .servlet("ProtectedServlet", ProtectedServlet.class.getName())
+                .servlet("ProtectedServlet", ProtectedServlet.class)
                 .servletMapping("ProtectedServlet", "/protected/servlet")
                 .buildAndStart();
 


### PR DESCRIPTION
Fixes #2363

#2363 This creates an initializer to be run separately, if needed, after all
servlets have been discovered. Splitting this up allows us to create the
authorization service early, but not yet commit the permissions.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>

## Required

Associated issue: #2363
