### PR TITLE
#2367 Add build fast script

### DIFF
--- a/build_fast.sh
+++ b/build_fast.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Fast builder for Piranha. Excludes tests and test modules specifically incompatible with fast building.
+
+mvn clean install -T8 -DskipTests -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -pl -:piranha-test-mojarra,-:piranha-test-server,-:piranha-test-server-slim
+


### PR DESCRIPTION
Fixes #2367

#2367 Add build fast script; a script that builds in parallel and skips javadoc generation and testing. Useful for instance for making changes during debug sessions, where not all tests need to run all the time before trying out the new changes.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>

## Required

Associated issue: #2367
