### PR TITLE
Fixes issue #2529 - Run build workflow with JDK 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17' ]
+        java: [ '17', '18' ]
         os: [ubuntu-latest]
     steps:
     - name: Checkout Sources


### PR DESCRIPTION
## Required

Associated issue: #2529

Fixes #2529
