### PR TITLE
Fix - JSP used as a welcome page treated as static resource

### DIFF
--- a/core/impl/src/main/java/cloud/piranha/core/impl/DefaultInvocationFinder.java
+++ b/core/impl/src/main/java/cloud/piranha/core/impl/DefaultInvocationFinder.java
@@ -233,7 +233,8 @@ public class DefaultInvocationFinder {
             // Try if we have a welcome file that we can load via the default servlet
 
             for (String welcomeFile : webApplication.getManager().getWelcomeFileManager().getWelcomeFileList()) {
-                if (!isStaticResource(servletPath, pathInfo + welcomeFile)) {
+                if (!isStaticResource(servletPath, pathInfo + welcomeFile)
+                    || isJsp(welcomeFile)) {
                     continue;
                 }
 
@@ -245,7 +246,7 @@ public class DefaultInvocationFinder {
                 if ( // .jsp files are special in the system, as they are mapped to a servlet, but also
                         // have to be present at exactly that path as static resource. Additionally we have
                         // the required index.jsp welcome file, that may not actually be there.
-                        (welcomeFile.endsWith(".jsp") && !isStaticResource(servletPath, pathInfo + welcomeFile))) {
+                        ( isJsp(welcomeFile) && !isStaticResource(servletPath, pathInfo + welcomeFile))) {
                     continue;
                 }
 
@@ -265,6 +266,10 @@ public class DefaultInvocationFinder {
 
     private boolean isStaticResource(String servletPath, String pathInfo) throws MalformedURLException {
         return webApplication.getResource(addOrRemoveSlashIfNeeded(servletPath + (pathInfo == null ? "" : pathInfo))) != null;
+    }
+
+    private static boolean isJsp(String welcomeFile) {
+        return welcomeFile.endsWith(".jsp");
     }
 
     private String addOrRemoveSlashIfNeeded(String string) {


### PR DESCRIPTION
Defect: If browser points to / instead of to the jsp directly, the JSP is downloaded by the browser as a plain text file instead of rendering it as HTML.

## Required

Associated issue: fixes https://github.com/piranhacloud/piranha/issues/2586
