### PR TITLE
Fixes issue #3092 - Don't use shallow clone in the nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -166,6 +166,8 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Java
       uses: actions/setup-java@v2
       with:


### PR DESCRIPTION
## Required

Associated issue: #3092 
