### PR TITLE
Fixes issue #3345 - Make sure Java 18 and newer modules are released when running release with Java 20

### DIFF
--- a/core/impl/pom.xml
+++ b/core/impl/pom.xml
@@ -56,19 +56,16 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
-            <version>5.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
-            <version>5.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
-            <version>5.6.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -61,7 +61,7 @@
         <profile>
             <id>jdk20</id>
             <activation>
-                <jdk>[20,)</jdk>
+                <jdk>20</jdk>
             </activation>
             <modules>
                 <module>virtual</module>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -59,9 +59,9 @@
 
     <profiles>
         <profile>
-            <id>jdk19</id>
+            <id>jdk20</id>
             <activation>
-                <jdk>19</jdk>
+                <jdk>[20,)</jdk>
             </activation>
             <modules>
                 <module>virtual</module>

--- a/http/virtual/pom.xml
+++ b/http/virtual/pom.xml
@@ -33,7 +33,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>19</release>
+                    <release>20</release>
                     <compilerArgs>
                         <arg>--enable-preview</arg>
                     </compilerArgs>

--- a/test/embedded/pom.xml
+++ b/test/embedded/pom.xml
@@ -35,7 +35,7 @@
         <profile>
             <id>jdk20</id>
             <activation>
-                <jdk>[20,)</jdk>
+                <jdk>20</jdk>
             </activation>
             <modules>
                 <module>springboot-virtualthreads</module>

--- a/test/embedded/pom.xml
+++ b/test/embedded/pom.xml
@@ -33,9 +33,9 @@
 
     <profiles>
         <profile>
-            <id>jdk19</id>
+            <id>jdk20</id>
             <activation>
-                <jdk>19</jdk>
+                <jdk>[20,)</jdk>
             </activation>
             <modules>
                 <module>springboot-virtualthreads</module>

--- a/test/embedded/springboot-virtualthreads/pom.xml
+++ b/test/embedded/springboot-virtualthreads/pom.xml
@@ -54,7 +54,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>19</release>
+                    <release>20</release>
                     <enablePreview>true</enablePreview>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Required

Associated issue: #3345 
