### PR TITLE
Fixes #3562 - Compliance report: artifact name should not start with 'spring-boot'

### DIFF
--- a/spring/spring-boot-starter-piranha-embedded/pom.xml
+++ b/spring/spring-boot-starter-piranha-embedded/pom.xml
@@ -9,10 +9,10 @@
         <version>23.11.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spring-boot-starter-piranha-embedded</artifactId>
+    <artifactId>piranha-embedded-spring-boot-starter</artifactId>
     <packaging>jar</packaging>
 
-    <name>Piranha - Spring - Piranha Embedded Starter</name>
+    <name>Piranha - Spring - Piranha Embedded Spring Boot Starter</name>
     <description>
         This module delivers the Spring Boot starter for Piranha Embedded.
     </description>

--- a/test/embedded/springboot-virtualthreads/pom.xml
+++ b/test/embedded/springboot-virtualthreads/pom.xml
@@ -37,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>cloud.piranha.spring</groupId>
-            <artifactId>spring-boot-starter-piranha-embedded</artifactId>
+            <artifactId>piranha-embedded-spring-boot-starter</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/test/embedded/springboot/pom.xml
+++ b/test/embedded/springboot/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>cloud.piranha.spring</groupId>
-            <artifactId>spring-boot-starter-piranha-embedded</artifactId>
+            <artifactId>piranha-embedded-spring-boot-starter</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
## Required

Associated issue: #3562 
