### PR TITLE
Fixes #3834 - Update dependencies

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -33,7 +33,7 @@
         <jakarta.security.enterprise-api.version>3.0.0</jakarta.security.enterprise-api.version>
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <jakarta.servlet.jsp-api.version>3.1.1</jakarta.servlet.jsp-api.version>
-        <jakarta.servlet.jsp.jstl-api.version>3.0.0</jakarta.servlet.jsp.jstl-api.version>
+        <jakarta.servlet.jsp.jstl-api.version>3.0.1</jakarta.servlet.jsp.jstl-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>

--- a/extension/eclipse-jersey/pom.xml
+++ b/extension/eclipse-jersey/pom.xml
@@ -15,7 +15,7 @@
     <name>Piranha - Extension - Eclipse Jersey</name>
 
     <properties>
-        <jersey.version>3.1.7</jersey.version>
+        <jersey.version>3.1.8</jersey.version>
     </properties>
 
     <dependencies>

--- a/extension/eclipse-parsson/pom.xml
+++ b/extension/eclipse-parsson/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <name>Piranha - Extension - Eclipse Parsson</name>
     <properties>
-        <parsson.version>1.1.6</parsson.version>
+        <parsson.version>1.1.7</parsson.version>
     </properties>
     <dependencies>
         <!-- compile -->

--- a/extension/eclipse-yasson/pom.xml
+++ b/extension/eclipse-yasson/pom.xml
@@ -14,7 +14,7 @@
 
     <name>Piranha - Extension - Eclipse Yasson</name>
     <properties>
-        <yasson.version>3.0.3</yasson.version>
+        <yasson.version>3.0.4</yasson.version>
     </properties>
     <dependencies>
         <!-- compile -->

--- a/extension/eclipselink/pom.xml
+++ b/extension/eclipselink/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <name>Piranha - Extension - EclipseLink</name>
     <properties>
-        <eclipselink.version>4.0.3</eclipselink.version>
+        <eclipselink.version>4.0.4</eclipselink.version>
     </properties>
     <dependencies>
         <!-- compile -->

--- a/extension/hazelcast/pom.xml
+++ b/extension/hazelcast/pom.xml
@@ -11,6 +11,7 @@
     <packaging>jar</packaging>
     <name>Piranha - Extension - Hazelcast</name>
     <properties>
+        <!-- kept at 5.4.0 because 5.5.0 adds remote repositories -->
         <hazelcast.version>5.4.0</hazelcast.version>
     </properties>
     <dependencies>

--- a/http/netty/pom.xml
+++ b/http/netty/pom.xml
@@ -14,7 +14,7 @@
 
     <name>Piranha - HTTP - Netty Integration</name>
     <properties>
-        <netty.version>4.1.111.Final</netty.version>
+        <netty.version>4.1.112.Final</netty.version>
     </properties>
     <dependencies>
         <!-- compile -->

--- a/http/undertow/pom.xml
+++ b/http/undertow/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <name>Piranha - HTTP - Undertow Integration</name>
     <properties>
-        <undertow.version>2.3.14.Final</undertow.version>        
+        <undertow.version>2.3.15.Final</undertow.version>        
     </properties>
     <dependencies>
         <!-- compile -->

--- a/pom.xml
+++ b/pom.xml
@@ -74,16 +74,16 @@
     <properties>
         <!-- dependencies -->
         <arquillian.version>1.8.0.Final</arquillian.version>
-        <bcel.version>6.9.0</bcel.version>
+        <bcel.version>6.10.0</bcel.version>
         <checkstyle.version>10.17.0</checkstyle.version>
         <free-port-finder.version>1.1.1</free-port-finder.version>
         <htmlunit.version>2.70.0</htmlunit.version>
-        <h2.version>2.2.224</h2.version>
+        <h2.version>2.3.232</h2.version>
         <jandex.version>3.1.8</jandex.version>
         <jboss-classfilewriter.version>1.3.1.Final</jboss-classfilewriter.version>
         <junit-pioneer.version>2.2.0</junit-pioneer.version>
-        <junit-platform-launcher.version>1.11.0-M2</junit-platform-launcher.version>
-        <junit.version>5.11.0-M2</junit.version>
+        <junit-platform-launcher.version>1.11.0</junit-platform-launcher.version>
+        <junit.version>5.11.0</junit.version>
         <maven-plugin-annotations.version>3.13.1</maven-plugin-annotations.version>
         <maven-plugin-api.version>4.0.0-beta-3</maven-plugin-api.version>
         <maven-plugin-tools-annotations.version>3.13.1</maven-plugin-tools-annotations.version>


### PR DESCRIPTION
1. Update JSTL API to 3.0.1
2. Update Eclipse Jersey to 3.1.8
3. Update Eclipse Parsson to 1.1.7
4. Update Eclipse Yasson to 3.0.4
5. Update EclpseLink to 4.0.4
6. Update Netty to 4.1.112.Final
7. Update Undertow to 2.3.15.Final
8. Update Apache BCEL to 6.10.0
9. Update H2 to 2.3.232
10. Update JUnit Platform Launcher to 1.11.0
11. Update JUnit to 5.11.0