### PR TITLE
Fixes #4801 - Fix Jakarta REST TCK JAXRSSigTestIT#signatureTest failure

### DIFF
--- a/test/tck/coreprofile/rest/runner/pom.xml
+++ b/test/tck/coreprofile/rest/runner/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <hamcrest.version>3.0</hamcrest.version>
+        <jimage.dir>${project.build.directory}/jimage</jimage.dir>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -80,6 +81,11 @@
             <version>${commons-httpclient.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -107,6 +113,8 @@
                         <junit.log.traceflag>true</junit.log.traceflag>
                         <porting.ts.url.class.1>ee.jakarta.tck.ws.rs.lib.implementation.sun.common.SunRIURL</porting.ts.url.class.1>
                         <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>
+                        <jimage.dir>${jimage.dir}</jimage.dir>
+                        <signature.sigTestClasspath>${settings.localRepository}/jakarta/ws/rs/jakarta.ws.rs-api/4.0.0/jakarta.ws.rs-api-4.0.0.jar:${jimage.dir}/java.base:${jimage.dir}/java.rmi:${jimage.dir}/java.sql:${jimage.dir}/java.naming</signature.sigTestClasspath>
                         <webServerHost>localhost</webServerHost>
                         <webServerPort>8080</webServerPort>
                     </systemPropertyVariables>


### PR DESCRIPTION
## Problem
The test JAXRSSigTestIT#signatureTest in the Jakarta REST TCK was failing with ClassNotFoundException and NullPointerException on signature test classpath.

## Root Cause
Missing SignatureTest tooling configuration in the REST TCK runner.

## Solution
Add minimal SignatureTest configuration to test/tck/coreprofile/rest/runner/pom.xml:
- Add jakarta.tck:sigtest-maven-plugin test dependency
- Add jimage.dir property for JDK module extraction
- Add signature.sigTestClasspath system property

## Verification
✅ Target test JAXRSSigTestIT#signatureTest now PASSES
✅ Full suite: 1184 tests, 0 failures, 122 errors (pre-existing), 1 skip
✅ Verified stable after upstream git pull with updated tooling versions

Fixes #4801