### PR TITLE
fix: update dependency versions and replace StructuredTaskScope

### DIFF
--- a/extension/soteria/pom.xml
+++ b/extension/soteria/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
-            <artifactId>jakarta.security.enterprise</artifactId>
+            <artifactId>soteria</artifactId>
             <scope>compile</scope>
         </dependency>
         <!-- test -->

--- a/http/virtual/src/main/java/cloud/piranha/http/virtual/VirtualHttpServer.java
+++ b/http/virtual/src/main/java/cloud/piranha/http/virtual/VirtualHttpServer.java
@@ -38,7 +38,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.StructuredTaskScope;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -177,14 +176,16 @@ public class VirtualHttpServer implements HttpServer {
      * @throws InterruptedException if an error occurs
      */
     private void serve(ServerSocket serverSocket) throws IOException, InterruptedException {
-        try (StructuredTaskScope<Void> scope = new StructuredTaskScope<>()) {
-            try {
-                while (isRunning()) {
-                    Socket socket = serverSocket.accept();
-                    scope.fork(() -> handle(socket));
-                }
-            } finally {
-                scope.join().shutdown();
+        try (ExecutorService virtualExecutor = Executors.newVirtualThreadPerTaskExecutor()) {
+            while (isRunning()) {
+                Socket socket = serverSocket.accept();
+                virtualExecutor.execute(() -> {
+                    try {
+                        handle(socket);
+                    } catch (IOException ioe) {
+                        LOGGER.log(WARNING, ioe);
+                    }
+                });
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,11 @@
         <checkstyle.version>10.21.2</checkstyle.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <commons-fileupload2-jakarta-servlet6.version>2.0.0-M4</commons-fileupload2-jakarta-servlet6.version>
-        <concurro.version>3.1.0-M6</concurro.version>
+        <concurro.version>3.1.0</concurro.version>
         <crac.version>0.1.3</crac.version>
         <eclipselink.version>5.0.0-B07</eclipselink.version>
-        <epicyro.version>3.1.0</epicyro.version>
-        <exousia.version>3.0.0-M3</exousia.version>
+        <epicyro.version>3.1.1</epicyro.version>
+        <exousia.version>3.0.1</exousia.version>
         <expressly.version>6.0.0</expressly.version>
         <free-port-finder.version>1.1.1</free-port-finder.version>
         <glassfish-client-ee11.version>1.8</glassfish-client-ee11.version>
@@ -124,7 +124,7 @@
         <shrinkwrap-impl-base.version>2.0.0-beta-2</shrinkwrap-impl-base.version>
         <shrinkwrap-descriptors-api-base.version>2.0.0</shrinkwrap-descriptors-api-base.version>
         <shrinkwrap-resolver.version>3.3.3</shrinkwrap-resolver.version>
-        <soteria.version>4.0.0-M3</soteria.version>
+        <soteria.version>4.0.2</soteria.version>
         <spring-boot.version>3.5.7</spring-boot.version>
         <testcontainers.version>2.0.1</testcontainers.version>
         <transact-cdi-beans.version>1.0.1</transact-cdi-beans.version>
@@ -349,7 +349,7 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish.soteria</groupId>
-                <artifactId>jakarta.security.enterprise</artifactId>
+                <artifactId>soteria</artifactId>
                 <version>${soteria.version}</version>
             </dependency>
             <!-- Eclipse Tyrus -->


### PR DESCRIPTION
## Summary

Several dependencies were pinned to milestone/snapshot versions whose Sonatype staging
slots are now closed (HTTP 402), breaking the build. This PR upgrades them to the
nearest GA releases available on Maven Central and fixes a compile error caused by a
JDK 25 API change.

## Changes

### Dependency version bumps (pom.xml)

| Property | Old | New | Reason |
|---|---|---|---|
| `concurro.version` | 3.1.0-M6 | 3.1.0 | Staging slot closed; GA on Central |
| `epicyro.version` | 3.1.0 | 3.1.1 | Staging slot closed; 3.1.1 on Central |
| `exousia.version` | 3.0.0-M3 | 3.0.1 | Staging slot closed; 3.0.1 on Central |
| `soteria.version` | 4.0.0-M3 | 4.0.2 | Staging slot closed; 4.0.2 on Central |

### Soteria artifactId rename (pom.xml + extension/soteria/pom.xml)

The `org.glassfish.soteria` artifact was renamed from `jakarta.security.enterprise`
to `soteria` starting with version 4.x. Updated both the BOM entry and the module
dependency.

### VirtualHttpServer (http/virtual)

`StructuredTaskScope` became a preview API requiring `--enable-preview` in JDK 24+,
and the inner class `ShutdownOnFailure` was removed in JDK 25 (JEP 499). Replaced
with `Executors.newVirtualThreadPerTaskExecutor()` which is stable since JDK 21.

## Testing

`mvn -B -DskipTests=true -DskipITs=true -ntp clean install` — BUILD SUCCESS (GraalVM
Community JDK 25.0.1).
