### PR TITLE
Fixes #4804 - Fix broken dependency versions and JDK 25 compile error in VirtualHttpServer

### DIFF
--- a/extension/soteria/pom.xml
+++ b/extension/soteria/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
-            <artifactId>jakarta.security.enterprise</artifactId>
+            <artifactId>soteria</artifactId>
             <scope>compile</scope>
         </dependency>
         <!-- test -->

--- a/http/virtual/src/main/java/cloud/piranha/http/virtual/VirtualHttpServer.java
+++ b/http/virtual/src/main/java/cloud/piranha/http/virtual/VirtualHttpServer.java
@@ -38,7 +38,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.StructuredTaskScope;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -177,14 +176,16 @@ public class VirtualHttpServer implements HttpServer {
      * @throws InterruptedException if an error occurs
      */
     private void serve(ServerSocket serverSocket) throws IOException, InterruptedException {
-        try (StructuredTaskScope<Void> scope = new StructuredTaskScope<>()) {
-            try {
-                while (isRunning()) {
-                    Socket socket = serverSocket.accept();
-                    scope.fork(() -> handle(socket));
-                }
-            } finally {
-                scope.join().shutdown();
+        try (ExecutorService virtualExecutor = Executors.newVirtualThreadPerTaskExecutor()) {
+            while (isRunning()) {
+                Socket socket = serverSocket.accept();
+                virtualExecutor.execute(() -> {
+                    try {
+                        handle(socket);
+                    } catch (IOException ioe) {
+                        LOGGER.log(WARNING, ioe);
+                    }
+                });
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,11 @@
         <checkstyle.version>10.21.2</checkstyle.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <commons-fileupload2-jakarta-servlet6.version>2.0.0-M4</commons-fileupload2-jakarta-servlet6.version>
-        <concurro.version>3.1.0-M6</concurro.version>
+        <concurro.version>3.1.0</concurro.version>
         <crac.version>0.1.3</crac.version>
         <eclipselink.version>5.0.0-B07</eclipselink.version>
-        <epicyro.version>3.1.0</epicyro.version>
-        <exousia.version>3.0.0-M3</exousia.version>
+        <epicyro.version>3.1.1</epicyro.version>
+        <exousia.version>3.0.1</exousia.version>
         <expressly.version>6.0.0</expressly.version>
         <free-port-finder.version>1.1.1</free-port-finder.version>
         <glassfish-client-ee11.version>1.8</glassfish-client-ee11.version>
@@ -124,7 +124,7 @@
         <shrinkwrap-impl-base.version>2.0.0-beta-2</shrinkwrap-impl-base.version>
         <shrinkwrap-descriptors-api-base.version>2.0.0</shrinkwrap-descriptors-api-base.version>
         <shrinkwrap-resolver.version>3.3.3</shrinkwrap-resolver.version>
-        <soteria.version>4.0.0-M3</soteria.version>
+        <soteria.version>4.0.2</soteria.version>
         <spring-boot.version>3.5.7</spring-boot.version>
         <testcontainers.version>2.0.1</testcontainers.version>
         <transact-cdi-beans.version>1.0.1</transact-cdi-beans.version>
@@ -349,7 +349,7 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish.soteria</groupId>
-                <artifactId>jakarta.security.enterprise</artifactId>
+                <artifactId>soteria</artifactId>
                 <version>${soteria.version}</version>
             </dependency>
             <!-- Eclipse Tyrus -->


### PR DESCRIPTION
## Problem

Several dependencies are pinned to milestone/snapshot versions whose Sonatype staging
slots are now closed (HTTP 402), breaking the build on a clean Maven local repository.
Additionally, `VirtualHttpServer` uses `StructuredTaskScope.ShutdownOnFailure` which
was removed in JDK 25 (JEP 499), causing a compile error.

## Root Cause

- `concurro:3.1.0-M6`, `epicyro:3.1.0`, `exousia:3.0.0-M3`, `soteria:4.0.0-M3` – staging slots closed
- `soteria` 4.x renamed its artifact from `jakarta.security.enterprise` to `soteria`
- `StructuredTaskScope.ShutdownOnFailure` removed in JDK 25

## Solution

Minimal changes to three files:

- `pom.xml`: concurro 3.1.0-M6→3.1.0, epicyro 3.1.0→3.1.1, exousia 3.0.0-M3→3.0.1, soteria 4.0.0-M3→4.0.2, soteria artifactId rename
- `extension/soteria/pom.xml`: soteria artifactId `jakarta.security.enterprise` → `soteria`
- `VirtualHttpServer.java`: replace preview `StructuredTaskScope` with stable `Executors.newVirtualThreadPerTaskExecutor()` (JDK 21+)

## Verification

✅ `mvn -B -DskipTests=true -DskipITs=true -ntp clean install` — BUILD SUCCESS (GraalVM Community JDK 25.0.1)

Fixes #4804
