### PR TITLE
Fixes #4806 - Fix Jakarta REST TCK JAXRSClientIT#serializationFromResourceTest failure

### DIFF
--- a/test/tck/coreprofile/rest/runner/pom.xml
+++ b/test/tck/coreprofile/rest/runner/pom.xml
@@ -84,6 +84,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
## Problem

`JAXRSClientIT#serializationFromResourceTest` fails with:

```
java.lang.IllegalArgumentException: The method named "$jacocoInit" is not specified by class ee.jakarta.tck.ws.rs.api.rs.core.link.Resource.
```

## Root Cause

JaCoCo is active by default for the whole build (inherited from the root POM via `prepare-agent`).
It instruments every class by injecting a synthetic `$jacocoInit` method.
`serializationFromResourceTest` iterates over all declared methods of the TCK `Resource` class
via reflection and calls `UriBuilder.fromMethod()` on each — including the synthetic JaCoCo method —
causing Jersey to throw `IllegalArgumentException`.

## Solution

Skip JaCoCo in `test/tck/coreprofile/rest/runner/pom.xml` by adding a JaCoCo plugin entry
with `<skip>true</skip>`, overriding the inherited root-POM configuration.

## Verification

✅ Target test `JAXRSClientIT#serializationFromResourceTest` now PASSES
✅ No regressions in the runner module

Fixes #4806
