### PR TITLE
Fixes #4808 - Fix Jakarta REST TCK beanparam Connection refused due to stale PID file

### DIFF
--- a/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
+++ b/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
@@ -317,12 +317,52 @@ public class ManagedPiranhaContainer implements DeployableContainer<ManagedPiran
     }
 
     /**
+     * Kill any process currently listening on the given port.
+     *
+     * @param port the port to free up.
+     */
+    private void killProcessOnPort(int port) {
+        try {
+            ProcessBuilder finder = new ProcessBuilder(
+                    "sh", "-c",
+                    "lsof -ti tcp:" + port + " -sTCP:LISTEN");
+            finder.redirectErrorStream(true);
+            Process findProcess = finder.start();
+            String pids = new String(findProcess.getInputStream().readAllBytes()).trim();
+            findProcess.waitFor(5, TimeUnit.SECONDS);
+            if (!pids.isEmpty()) {
+                for (String pid : pids.split("\\s+")) {
+                    if (!pid.isEmpty()) {
+                        LOGGER.log(WARNING, "Port {0} is still in use by PID {1}, killing it", port, pid);
+                        new ProcessBuilder("kill", "-9", pid)
+                                .start()
+                                .waitFor(5, TimeUnit.SECONDS);
+                    }
+                }
+                // Brief pause so the OS releases the port
+                Thread.sleep(200);
+            }
+        } catch (IOException | InterruptedException e) {
+            LOGGER.log(WARNING, "Could not clean up port {0}: {1}", port, e.getMessage());
+        }
+    }
+
+    /**
      * Start Piranha.
      *
      * @param runtimeDirectory the runtime directory.
      * @param warFile the WAR filename.
      */
     private void startPiranha(File runtimeDirectory, File warFile) throws IOException, DeploymentException {
+        killProcessOnPort(configuration.getHttpPort());
+        File stalePidFile = new File(runtimeDirectory, PID_FILENAME);
+        if (stalePidFile.exists()) {
+            try {
+                Files.delete(stalePidFile.toPath());
+            } catch (IOException ioe) {
+                LOGGER.log(WARNING, "Could not delete stale PID file: {0}", ioe.getMessage());
+            }
+        }
         List<String> commands = new ArrayList<>();
         StringBuilder classpath = new StringBuilder();
         commands.add("java");


### PR DESCRIPTION
## Problem

The Jakarta REST TCK `beanparam.header.plain.JAXRSClientIT` (and other server-side tests that reuse the same runtime directory) fail with `Connection refused` on every test run after the first.

## Root Cause

`ManagedPiranhaContainer.startPiranha()` waits for Piranha to be ready by polling for the existence of `tmp/piranha.pid`. When the same runtime directory is reused across Maven runs, the PID file left by the previous run is still on disk. The readiness loop exits immediately (the file already exists), so the test client starts sending HTTP requests before the new Piranha process has bound to port 8080.

A secondary issue is that the previous Piranha process may still be holding port 8080 at the start of the next run.

## Solution

In `startPiranha()`:
1. Call `killProcessOnPort()` to terminate any lingering process on the configured HTTP port before starting a new one.
2. Delete any pre-existing `tmp/piranha.pid` file before launching the new process, so the readiness loop waits properly for the new process to write its PID file.

## Verification

`beanparam.header.plain.JAXRSClientIT` — previously 16 errors (`Connection refused`) in 30s — now passes (16/16) in ~4s.

Fixes #4808
