### PR TITLE
Fixes #4810 - Fix Jakarta REST TCK runner forked process timeout

### DIFF
--- a/test/tck/coreprofile/rest/runner/pom.xml
+++ b/test/tck/coreprofile/rest/runner/pom.xml
@@ -114,6 +114,7 @@
                     </dependenciesToScan>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <forkedProcessTimeoutInSeconds>120</forkedProcessTimeoutInSeconds>
                     <systemPropertyVariables>
                         <arquillian.launch>piranha</arquillian.launch>
                         <cts.harness.debug>true</cts.harness.debug>


### PR DESCRIPTION
## Problem

The Jakarta REST TCK runner uses the default Failsafe `forkedProcessTimeoutInSeconds` value (30 seconds). Some server-side test classes take longer than 30 seconds for Piranha to start, deploy, and process the full test suite, causing the forked JVM to be killed mid-run and reporting spurious test failures.

## Solution

Set `forkedProcessTimeoutInSeconds` to 120 in the REST TCK runner `pom.xml`.

## Verification

Server-side TCK test classes that previously timed out now complete within the 120-second window.

Fixes #4810
