### PR TITLE
Fixes #4813 - Fix Jakarta REST TCK requestcontext security test failures

### DIFF
--- a/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
+++ b/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
@@ -381,6 +381,13 @@ public class ManagedPiranhaContainer implements DeployableContainer<ManagedPiran
             }
         }
 
+        if (!configuration.getCallerName().isEmpty()) {
+            commands.add("-Dio.piranha.identitystore.callers=<callers><caller callername=\""
+                    + configuration.getCallerName() + "\" password=\""
+                    + configuration.getCallerPassword() + "\" groups=\""
+                    + configuration.getCallerGroups() + "\"/></callers>");
+        }
+
         if (configuration.isDebug()) {
             commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=localhost:9009");
         }

--- a/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
+++ b/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
@@ -317,12 +317,52 @@ public class ManagedPiranhaContainer implements DeployableContainer<ManagedPiran
     }
 
     /**
+     * Kill any process currently listening on the given port.
+     *
+     * @param port the port to free up.
+     */
+    private void killProcessOnPort(int port) {
+        try {
+            ProcessBuilder finder = new ProcessBuilder(
+                    "sh", "-c",
+                    "lsof -ti tcp:" + port + " -sTCP:LISTEN");
+            finder.redirectErrorStream(true);
+            Process findProcess = finder.start();
+            String pids = new String(findProcess.getInputStream().readAllBytes()).trim();
+            findProcess.waitFor(5, TimeUnit.SECONDS);
+            if (!pids.isEmpty()) {
+                for (String pid : pids.split("\\s+")) {
+                    if (!pid.isEmpty()) {
+                        LOGGER.log(WARNING, "Port {0} is still in use by PID {1}, killing it", port, pid);
+                        new ProcessBuilder("kill", "-9", pid)
+                                .start()
+                                .waitFor(5, TimeUnit.SECONDS);
+                    }
+                }
+                // Brief pause so the OS releases the port
+                Thread.sleep(200);
+            }
+        } catch (IOException | InterruptedException e) {
+            LOGGER.log(WARNING, "Could not clean up port {0}: {1}", port, e.getMessage());
+        }
+    }
+
+    /**
      * Start Piranha.
      *
      * @param runtimeDirectory the runtime directory.
      * @param warFile the WAR filename.
      */
     private void startPiranha(File runtimeDirectory, File warFile) throws IOException, DeploymentException {
+        killProcessOnPort(configuration.getHttpPort());
+        File stalePidFile = new File(runtimeDirectory, PID_FILENAME);
+        if (stalePidFile.exists()) {
+            try {
+                Files.delete(stalePidFile.toPath());
+            } catch (IOException ioe) {
+                LOGGER.log(WARNING, "Could not delete stale PID file: {0}", ioe.getMessage());
+            }
+        }
         List<String> commands = new ArrayList<>();
         StringBuilder classpath = new StringBuilder();
         commands.add("java");

--- a/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainerConfiguration.java
+++ b/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainerConfiguration.java
@@ -62,6 +62,21 @@ import static java.lang.System.Logger.Level.INFO;
  * <td>if not set an unused port will be automatically chosen</td>
  * </tr>
  * <tr>
+ * <td>piranha.callerName</td>
+ * <td>The username to seed into the in-memory identity store</td>
+ * <td>not set by default</td>
+ * </tr>
+ * <tr>
+ * <td>piranha.callerPassword</td>
+ * <td>The password for the caller to seed into the in-memory identity store</td>
+ * <td>not set by default</td>
+ * </tr>
+ * <tr>
+ * <td>piranha.callerGroups</td>
+ * <td>The comma-separated groups for the caller to seed into the in-memory identity store</td>
+ * <td>not set by default</td>
+ * </tr>
+ * <tr>
  * <td>piranha.jvmArguments</td>
  * <td>The string with JVM arguments to pass to the Piranha process</td>
  * <td>no additional JVM arguments are passed by default</td>
@@ -87,6 +102,21 @@ public class ManagedPiranhaContainerConfiguration implements ContainerConfigurat
      * Stores the logger.
      */
     private static final System.Logger LOGGER = System.getLogger(ManagedPiranhaContainerConfiguration.class.getName());
+
+    /**
+     * Stores the caller groups.
+     */
+    private String callerGroups = System.getProperty("piranha.callerGroups", "");
+
+    /**
+     * Stores the caller name.
+     */
+    private String callerName = System.getProperty("piranha.callerName", "");
+
+    /**
+     * Stores the caller password.
+     */
+    private String callerPassword = System.getProperty("piranha.callerPassword", "");
 
     /**
      * Stores the distribution to use.
@@ -122,6 +152,33 @@ public class ManagedPiranhaContainerConfiguration implements ContainerConfigurat
      * Constructor.
      */
     public ManagedPiranhaContainerConfiguration() {
+    }
+
+    /**
+     * Get the caller groups.
+     *
+     * @return the caller groups.
+     */
+    public String getCallerGroups() {
+        return callerGroups;
+    }
+
+    /**
+     * Get the caller name.
+     *
+     * @return the caller name.
+     */
+    public String getCallerName() {
+        return callerName;
+    }
+
+    /**
+     * Get the caller password.
+     *
+     * @return the caller password.
+     */
+    public String getCallerPassword() {
+        return callerPassword;
     }
 
     /**
@@ -179,6 +236,33 @@ public class ManagedPiranhaContainerConfiguration implements ContainerConfigurat
      */
     public boolean isSuspend() {
         return suspend;
+    }
+
+    /**
+     * Set the caller groups.
+     *
+     * @param callerGroups the caller groups.
+     */
+    public void setCallerGroups(String callerGroups) {
+        this.callerGroups = callerGroups;
+    }
+
+    /**
+     * Set the caller name.
+     *
+     * @param callerName the caller name.
+     */
+    public void setCallerName(String callerName) {
+        this.callerName = callerName;
+    }
+
+    /**
+     * Set the caller password.
+     *
+     * @param callerPassword the caller password.
+     */
+    public void setCallerPassword(String callerPassword) {
+        this.callerPassword = callerPassword;
     }
 
     /**

--- a/extension/coreprofile/pom.xml
+++ b/extension/coreprofile/pom.xml
@@ -51,6 +51,18 @@
         </dependency>
         <dependency>
             <groupId>cloud.piranha.extension</groupId>
+            <artifactId>piranha-extension-policy</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>cloud.piranha.extension</groupId>
+            <artifactId>piranha-extension-security-servlet</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>cloud.piranha.extension</groupId>
             <artifactId>piranha-extension-jersey</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/extension/coreprofile/src/main/java/cloud/piranha/extension/coreprofile/CoreProfileExtension.java
+++ b/extension/coreprofile/src/main/java/cloud/piranha/extension/coreprofile/CoreProfileExtension.java
@@ -33,7 +33,10 @@ import cloud.piranha.extension.annotationscan.AnnotationScanExtension;
 import cloud.piranha.extension.annotationscan.classfile.ClassfileAnnotationScanExtension;
 import cloud.piranha.extension.handlestypes.HandlesTypesExtension;
 import cloud.piranha.extension.herring.HerringExtension;
+import cloud.piranha.extension.policy.PolicyExtension;
 import cloud.piranha.extension.scinitializer.ServletContainerInitializerExtension;
+import cloud.piranha.extension.security.servlet.ServletSecurityExtension;
+import cloud.piranha.extension.security.servlet.ServletSecurityManagerExtension;
 import cloud.piranha.extension.webxml.WebXmlExtension;
 import cloud.piranha.extension.weld.WeldExtension;
 
@@ -52,11 +55,14 @@ public class CoreProfileExtension implements WebApplicationExtension {
 
     @Override
     public void extend(WebApplicationExtensionContext context) {
+        context.add(PolicyExtension.class);                         // JavaPolicy
+        context.add(ServletSecurityManagerExtension.class);         // SecurityManager
         context.add(HandlesTypesExtension.class);                   // HandlesTypes support
         context.add(HerringExtension.class);                        // Herring (JNDI)
         context.add(WebXmlExtension.class);
         context.add(getAnnotationScanExtensionClass());
         context.add(WeldExtension.class);                           // CDI / Weld
+        context.add(ServletSecurityExtension.class);                // Security implementation
         context.add(ServletContainerInitializerExtension.class);    // ServletContainerInitializer
     }
 

--- a/extension/coreprofile/src/main/java/module-info.java
+++ b/extension/coreprofile/src/main/java/module-info.java
@@ -42,6 +42,7 @@
  *  <li>web.xml support</li>
  *  <li>Weld (CDI)</li>
  *  <li>Yasson (JSON-B)</li>
+ *  <li>Servlet security (Basic auth, security constraints)</li>
  * </ul>
  */
 module cloud.piranha.extension.coreprofile {
@@ -54,6 +55,8 @@ module cloud.piranha.extension.coreprofile {
     requires cloud.piranha.extension.handlestypes;
     requires cloud.piranha.extension.herring;
     requires cloud.piranha.extension.jersey;
+    requires cloud.piranha.extension.policy;
+    requires cloud.piranha.extension.security.servlet;
     requires cloud.piranha.extension.scinitializer;
     requires cloud.piranha.extension.webxml;
     requires cloud.piranha.extension.weld;

--- a/test/tck/coreprofile/rest/runner/pom.xml
+++ b/test/tck/coreprofile/rest/runner/pom.xml
@@ -114,6 +114,7 @@
                     </dependenciesToScan>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <forkedProcessTimeoutInSeconds>120</forkedProcessTimeoutInSeconds>
                     <systemPropertyVariables>
                         <arquillian.launch>piranha</arquillian.launch>
                         <cts.harness.debug>true</cts.harness.debug>

--- a/test/tck/coreprofile/rest/runner/pom.xml
+++ b/test/tck/coreprofile/rest/runner/pom.xml
@@ -125,6 +125,8 @@
                         <signature.sigTestClasspath>${settings.localRepository}/jakarta/ws/rs/jakarta.ws.rs-api/4.0.0/jakarta.ws.rs-api-4.0.0.jar:${jimage.dir}/java.base:${jimage.dir}/java.rmi:${jimage.dir}/java.sql:${jimage.dir}/java.naming</signature.sigTestClasspath>
                         <webServerHost>localhost</webServerHost>
                         <webServerPort>8080</webServerPort>
+                        <user>j2ee</user>
+                        <password>j2ee</password>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>  

--- a/test/tck/coreprofile/rest/runner/src/test/resources/arquillian.xml
+++ b/test/tck/coreprofile/rest/runner/src/test/resources/arquillian.xml
@@ -8,6 +8,9 @@
     <container qualifier="piranha" default="true">
         <configuration>
             <property name="httpPort">8080</property>
+            <property name="callerName">j2ee</property>
+            <property name="callerPassword">j2ee</property>
+            <property name="callerGroups">DIRECTOR</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
## Problem

The Jakarta REST TCK requestcontext.security.JAXRSClientIT tests fail because the coreprofile extension lacks security extensions and the Arquillian container cannot seed identity store credentials.

## Solution

- Add piranha-extension-policy and piranha-extension-security-servlet to the coreprofile extension.
- Add callerName/callerPassword/callerGroups to ManagedPiranhaContainerConfiguration to inject io.piranha.identitystore.callers into the Piranha JVM.
- Wire callerName=j2ee, callerPassword=j2ee, callerGroups=DIRECTOR in the REST TCK arquillian.xml.
